### PR TITLE
Add linting

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        toxenv: ["format", "build"]
+        toxenv: ["lint", "build"]
     env:
       TOXENV: ${{ matrix.toxenv }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,17 @@ deps =
     isort
 commands =
     black .
-    isort -rc src
-    isort -rc tests
+    isort --atomic -rc scripts src tests
+
+[testenv:lint]
+description = Run linting checks
+skip_install = True
+deps =
+    black
+    isort
+commands =
+    black --check .
+    isort --check-only --recursive scripts src tests
 
 [testenv:build]
 description = Build a wheel and source distribution


### PR DESCRIPTION
Currently this just enforces the same stuff that can be fixed automatically with `format`, so it seems like maybe there should be a better way to "single source" those, but this can always be changed later.