### PR TITLE
Improve cache tests and modify clear_cache

### DIFF
--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -104,9 +104,15 @@ class ZoneInfo(tzinfo):
         return obj
 
     @classmethod
-    def clear_cache(cls):
-        cls.__weak_cache.clear()
-        cls.__strong_cache.clear()
+    def clear_cache(cls, *, only_keys=None):
+        if only_keys is not None:
+            for key in only_keys:
+                cls.__weak_cache.pop(key, None)
+                cls.__strong_cache.pop(key, None)
+
+        else:
+            cls.__weak_cache.clear()
+            cls.__strong_cache.clear()
 
     def _load_tzdata(self, key):
         # TODO: Proper error for malformed keys?

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -429,6 +429,35 @@ class ZoneInfoCacheTest(TzPathUserMixin, unittest.TestCase):
 
         self.assertIs(zi0, zi1)
 
+    def test_clear_cache_one_key(self):
+        """Tests that you can clear a single key from the cache."""
+        la0 = ZoneInfo("America/Los_Angeles")
+        dub0 = ZoneInfo("Europe/Dublin")
+
+        ZoneInfo.clear_cache(only_keys=["America/Los_Angeles"])
+
+        la1 = ZoneInfo("America/Los_Angeles")
+        dub1 = ZoneInfo("Europe/Dublin")
+
+        self.assertIsNot(la0, la1)
+        self.assertIs(dub0, dub1)
+
+    def test_clear_cache_two_keys(self):
+        la0 = ZoneInfo("America/Los_Angeles")
+        dub0 = ZoneInfo("Europe/Dublin")
+        tok0 = ZoneInfo("Asia/Tokyo")
+
+        ZoneInfo.clear_cache(only_keys=["America/Los_Angeles", "Europe/Dublin"])
+
+        la1 = ZoneInfo("America/Los_Angeles")
+        dub1 = ZoneInfo("Europe/Dublin")
+        tok1 = ZoneInfo("Asia/Tokyo")
+
+        self.assertIsNot(la0, la1)
+        self.assertIsNot(dub0, dub1)
+        self.assertIs(tok0, tok1)
+
+
 @dataclasses.dataclass
 class ZoneOffset:
     tzname: str

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -416,6 +416,18 @@ class ZoneInfoCacheTest(TzPathUserMixin, unittest.TestCase):
 
         self.assertIsNot(tz0, tz1)
 
+    def test_cache_set_tzpath(self):
+        """Test that the cache persists when tzpath has been changed.
+
+        The PEP specifies that as long as a reference exists to one zone
+        with a given key, the primary constructor must continue to return
+        the same object.
+        """
+        zi0 = ZoneInfo("America/Los_Angeles")
+        with tzpath_context([]):
+            zi1 = ZoneInfo("America/Los_Angeles")
+
+        self.assertIs(zi0, zi1)
 
 @dataclasses.dataclass
 class ZoneOffset:


### PR DESCRIPTION
This adds the `only_keys` argument to `ZoneInfo.clear_cache`, which will allow for finer-grained control over the `ZoneInfo` instance cache.

It also refactors some of the cache-related tests.