### PR TITLE
Change guarantees about __str__ and __repr__

### DIFF
--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -100,6 +100,7 @@ class ZoneInfo(tzinfo):
         obj._key = key
         obj._file_path = None
         obj._load_file(fobj)
+        obj._file_repr = repr(fobj)
 
         return obj
 
@@ -212,7 +213,10 @@ class ZoneInfo(tzinfo):
             return repr(self)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(file_path={self._file_path!r}, key={self._key!r})"
+        if self._key is not None:
+            return f"{self.__class__.__name__}(key={self._key!r})"
+        else:
+            return f"{self.__class__.__name__}.from_file({self._file_repr})"
 
     def _find_tzfile(self, key):
         for search_path in TZPATH:

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -86,12 +86,32 @@ class TzPathUserMixin:
 
 
 class ZoneInfoTest(TzPathUserMixin, unittest.TestCase):
+    @property
+    def tzpath(self):
+        return [TEMP_DIR]
+
     def zone_from_key(self, key):
-        with open(ZONEINFO_DATA.path_from_key(key), "rb") as f:
-            return ZoneInfo.from_file(f, key=key)
+        return ZoneInfo(key)
 
     def zones(self):
         return ZoneDumpData.transition_keys()
+
+    def test_str(self):
+        # Zones constructed with a key must have str(zone) == key
+        for key in self.zones():
+            with self.subTest(key):
+                zi = self.zone_from_key(key)
+
+                self.assertEqual(str(zi), key)
+
+        # Zones with no key constructed should have str(zone) == repr(zone)
+        file_key = ZONEINFO_DATA.keys[0]
+        file_path = ZONEINFO_DATA.path_from_key(file_key)
+
+        with open(file_path, "rb") as f:
+            with self.subTest(test_name="Repr test", path=file_path):
+                zi_ff = ZoneInfo.from_file(f)
+                self.assertEqual(str(zi_ff), repr(zi_ff))
 
     def test_unambiguous(self):
         test_cases = []

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -113,6 +113,30 @@ class ZoneInfoTest(TzPathUserMixin, unittest.TestCase):
                 zi_ff = ZoneInfo.from_file(f)
                 self.assertEqual(str(zi_ff), repr(zi_ff))
 
+    def test_repr(self):
+        # The repr is not guaranteed, but I think we can insist that it at
+        # least contain the name of the class.
+        key = next(iter(self.zones()))
+
+        zi = ZoneInfo(key)
+        class_name = "ZoneInfo"
+        with self.subTest(name="from key"):
+            self.assertRegex(repr(zi), class_name)
+
+        file_key = ZONEINFO_DATA.keys[0]
+        file_path = ZONEINFO_DATA.path_from_key(file_key)
+        with open(file_path, "rb") as f:
+            zi_ff = ZoneInfo.from_file(f, key=file_key)
+
+        with self.subTest(name="from file with key"):
+            self.assertRegex(repr(zi_ff), class_name)
+
+        with open(file_path, "rb") as f:
+            zi_ff_nk = ZoneInfo.from_file(f)
+
+        with self.subTest(name="from file without key"):
+            self.assertRegex(repr(zi_ff_nk), class_name)
+
     def test_unambiguous(self):
         test_cases = []
         for key in self.zones():


### PR DESCRIPTION
This adds tests to comply with the guarantees from the PEP about the
properties of the `__str__` and the `__repr__`.