### PR TITLE
Add extra, tests for tzdata

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,8 +10,10 @@ jobs:
       matrix:
         python-version: [3.8]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        tzdata_extras: ["", "tzdata"]
     env:
       TOXENV: py
+      TEST_EXTRAS_TOX: ${{ matrix.tzdata_extras }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,5 +31,9 @@ python_requires = >=3.8
 [options.packages.find]
 where=src
 
+[options.extras_require]
+tzdata =
+    tzdata @ git+https://github.com/pganssle/tzdata.git
+
 [bdist_wheel]
 universal=1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ deps =
     pytest
     pytest-cov
     pytest-subtests
+extras =
+    {env:TEST_EXTRAS_TOX:}
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 commands =
     pytest {toxinidir} {posargs: --cov=zoneinfo --cov=tests}


### PR DESCRIPTION
This is done in separate jobs mainly to ensure that the test suite also works when `tzdata` is *not* installed.