### PR TITLE
Disable peephole optimizer on branch

### DIFF
--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -183,6 +183,10 @@ class ZoneInfoTest(TzPathUserMixin, unittest.TestCase):
                 elif zt.gap:
                     test_group = tests["gaps"]
                 else:
+                    # Assign a random variable here to disable the peephole
+                    # optimizer so that coverage can see this line.
+                    # See bpo-2506 for more information.
+                    no_peephole_opt = None
                     continue
 
                 # Cases are of the form key, dt, fold, offset


### PR DESCRIPTION
This is a long-running bug in coverage that manifests in many ways. When
the peephole optimizer eliminates a part of the code, it doesn't leave a
trace that coverage can see, so even if a line's effects are seen, the
code shows as uncovered.

It appears that this is happening here, but we can disable the optimizer
in this test by assigning to a random variable to force the branch to be
executed in a way that coverage can see it.

We could also add # pragma: nocover here, but I'd like to make sure that
this line is seen as covered, since otherwise it may mean that some of
our tests are erroneously being treated as folds or gaps.

More background reading:

- bpo-2506 https://bugs.python.org/issue2506
- https://github.com/nedbat/coveragepy/issues/772