### PR TITLE
Pickle behavior

### DIFF
--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -110,6 +110,9 @@ class ZoneInfo(tzinfo):
         obj._load_file(fobj)
         obj._file_repr = repr(fobj)
 
+        # Disable pickling for objects created from files
+        obj.__reduce__ = obj._file_reduce
+
         return obj
 
     @classmethod
@@ -228,6 +231,13 @@ class ZoneInfo(tzinfo):
 
     def __reduce__(self):
         return (self.__class__._unpickle, (self._key, self._from_cache))
+
+    def _file_reduce(self):
+        import pickle
+
+        raise pickle.PicklingError(
+            "Cannot pickle a ZoneInfo file created from a file stream."
+        )
 
     @classmethod
     def _unpickle(cls, key, from_cache, /):

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -764,6 +764,32 @@ class ZoneInfoPickleTest(TzPathUserMixin, unittest.TestCase):
                 with self.assertRaises(pickle.PicklingError):
                     pickle.dumps(zi)
 
+    def test_pickle_after_from_file(self):
+        # This may be a bit of paranoia, but this test is to ensure that no
+        # global state is maintained in order to handle the pickle cache and
+        # from_file behavior, and that it is possible to interweave the
+        # constructors of each of these and pickling/unpickling without issues.
+        key = "Europe/Dublin"
+        zi = ZoneInfo(key)
+
+        pkl_0 = pickle.dumps(zi)
+        zi_rt_0 = pickle.loads(pkl_0)
+        self.assertIs(zi, zi_rt_0)
+
+        with open(ZONEINFO_DATA.path_from_key(key), "rb") as f:
+            zi_ff = ZoneInfo.from_file(f, key=key)
+
+        pkl_1 = pickle.dumps(zi)
+        zi_rt_1 = pickle.loads(pkl_1)
+        self.assertIs(zi, zi_rt_1)
+
+        with self.assertRaises(pickle.PicklingError):
+            pickle.dumps(zi_ff)
+
+        pkl_2 = pickle.dumps(zi)
+        zi_rt_2 = pickle.loads(pkl_2)
+        self.assertIs(zi, zi_rt_2)
+
 
 @dataclasses.dataclass
 class ZoneOffset:

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -746,6 +746,24 @@ class ZoneInfoPickleTest(TzPathUserMixin, unittest.TestCase):
         with self.subTest(test="Not a cached object"):
             self.assertIsNot(zi_rt, zi_cache)
 
+    def test_from_file(self):
+        key = "Europe/Dublin"
+        with open(ZONEINFO_DATA.path_from_key(key), "rb") as f:
+            zi_nokey = ZoneInfo.from_file(f)
+
+            f.seek(0)
+            zi_key = ZoneInfo.from_file(f, key=key)
+
+        test_cases = [
+            (zi_key, "ZoneInfo with key"),
+            (zi_nokey, "ZoneInfo without key"),
+        ]
+
+        for zi, test_name in test_cases:
+            with self.subTest(test_name=test_name):
+                with self.assertRaises(pickle.PicklingError):
+                    pickle.dumps(zi)
+
 
 @dataclasses.dataclass
 class ZoneOffset:


### PR DESCRIPTION
I had not updated the reference implementation to actually do what the PEP says to do with regards to pickles.

I am not a pickle expert or anything, it seems like `__reduce__` is the way to go here, but maybe there's a better option?

I have not really seriously started optimizing for speed here, because I fully intend to create a C implementation as well, so the pure Python version.