### PR TITLE
Remove PYTHONTZPATH_APPEND

### DIFF
--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -50,11 +50,6 @@ def set_tzpath(tzpaths=None):
         else:
             base_tzpath = []
 
-        if "PYTHONTZPATH_APPEND" in os.environ:
-            base_tzpath.extend(
-                os.environ["PYTHONTZPATH_APPEND"].split(os.pathsep)
-            )
-
     TZPATH = tuple(base_tzpath)
 
 


### PR DESCRIPTION
The PEP has been updated to remove PYTHONTZPATH_APPEND as it's not clear what the use case is and there are some simple shell tricks you should be able to play to accomplish the same thing.