### PR TITLE
Move tzpath handling and file IO to common submodules

### DIFF
--- a/src/zoneinfo/__init__.py
+++ b/src/zoneinfo/__init__.py
@@ -1,4 +1,5 @@
 __all__ = ["ZoneInfo", "set_tzpath"]
 
+from ._tzpath import set_tzpath
 from ._version import __version__
-from ._zoneinfo import ZoneInfo, set_tzpath
+from ._zoneinfo import ZoneInfo

--- a/src/zoneinfo/__init__.py
+++ b/src/zoneinfo/__init__.py
@@ -1,5 +1,18 @@
-__all__ = ["ZoneInfo", "set_tzpath"]
+__all__ = ["ZoneInfo", "set_tzpath", "TZPATH"]
 
 from ._tzpath import set_tzpath
 from ._version import __version__
 from ._zoneinfo import ZoneInfo
+
+
+def __getattr__(name):
+    if name == "TZPATH":
+        from . import _tzpath
+
+        return _tzpath.TZPATH
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__ + ["__version__"])

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -13,7 +13,11 @@ def set_tzpath(tzpaths=None):
         base_tzpath = tzpaths
     else:
         if "PYTHONTZPATH" in os.environ:
-            base_tzpath = os.environ["PYTHONTZPATH"].split(os.pathsep)
+            env_var = os.environ["PYTHONTZPATH"]
+            if env_var:
+                base_tzpath = env_var.split(os.pathsep)
+            else:
+                base_tzpath = ()
         elif sys.platform != "win32":
             base_tzpath = [
                 "/usr/share/zoneinfo",
@@ -24,7 +28,7 @@ def set_tzpath(tzpaths=None):
 
             base_tzpath.sort(key=lambda x: not os.path.exists(x))
         else:
-            base_tzpath = []
+            base_tzpath = ()
 
     TZPATH = tuple(base_tzpath)
 

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+
+def set_tzpath(tzpaths=None):
+    global TZPATH
+    if tzpaths is not None:
+        if isinstance(tzpaths, (str, bytes)):
+            raise ValueError(
+                f"tzpaths must be a list or tuple, "
+                + f"not {type(tzpaths)}: {tzpaths}"
+            )
+        base_tzpath = tzpaths
+    else:
+        if "PYTHONTZPATH" in os.environ:
+            base_tzpath = os.environ["PYTHONTZPATH"].split(os.pathsep)
+        elif sys.platform != "win32":
+            base_tzpath = [
+                "/usr/share/zoneinfo",
+                "/usr/lib/zoneinfo",
+                "/usr/share/lib/zoneinfo",
+                "/etc/zoneinfo",
+            ]
+
+            base_tzpath.sort(key=lambda x: not os.path.exists(x))
+        else:
+            base_tzpath = []
+
+    TZPATH = tuple(base_tzpath)
+
+
+def find_tzfile(key):
+    """Retrieve the path to a TZif file from a key."""
+    for search_path in TZPATH:
+        filepath = os.path.join(search_path, key)
+        if os.path.isfile(filepath):
+            return filepath
+
+    return None
+
+
+TZPATH = ()
+set_tzpath()

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -6,7 +6,7 @@ def set_tzpath(tzpaths=None):
     global TZPATH
     if tzpaths is not None:
         if isinstance(tzpaths, (str, bytes)):
-            raise ValueError(
+            raise TypeError(
                 f"tzpaths must be a list or tuple, "
                 + f"not {type(tzpaths)}: {tzpaths}"
             )

--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -9,7 +9,7 @@ import sys
 import weakref
 from datetime import datetime, timedelta, timezone, tzinfo
 
-from . import _tzpath
+from . import _common, _tzpath
 
 EPOCH = datetime(1970, 1, 1)
 EPOCHORDINAL = datetime(1970, 1, 1).toordinal()
@@ -217,7 +217,7 @@ class ZoneInfo(tzinfo):
 
     def _load_file(self, fobj):
         # Retrieve all the data as it exists in the zoneinfo file
-        trans_idx, trans_utc, utcoff, isdst, abbr, tz_str = self._load_data(
+        trans_idx, trans_utc, utcoff, isdst, abbr, tz_str = _common.load_data(
             fobj
         )
 
@@ -255,96 +255,6 @@ class ZoneInfo(tzinfo):
             self._tz_after = _parse_tz_str(tz_str)
         else:
             self._tz_after = self._ttinfos[-1]
-
-    @classmethod
-    def _load_data(cls, fobj):
-        header = _TZifHeader.from_file(fobj)
-
-        if header.version == 1:
-            time_size = 4
-            time_type = "l"
-        else:
-            # Version 2+ has 64-bit integer transition times
-            time_size = 8
-            time_type = "q"
-
-            # Version 2+ also starts with a Version 1 header and data, which
-            # we need to skip now
-            skip_bytes = (
-                header.timecnt * 5
-                + header.typecnt * 6  # Transition times and types
-                + header.charcnt  # Local time type records
-                + header.leapcnt * 8  # Time zone designations
-                + header.isstdcnt  # Leap second records
-                + header.isutcnt  # Standard/wall indicators  # UT/local indicators
-            )
-
-            fobj.seek(skip_bytes, 1)
-
-            # Now we need to read the second header, which is not the same
-            # as the first
-            header = _TZifHeader.from_file(fobj)
-
-        typecnt = header.typecnt
-        timecnt = header.timecnt
-        charcnt = header.charcnt
-
-        # The data portion starts with timecnt transitions and indices
-        if timecnt:
-            trans_list_utc = struct.unpack(
-                f">{timecnt}{time_type}", fobj.read(timecnt * time_size)
-            )
-            trans_idx = struct.unpack(f">{timecnt}B", fobj.read(timecnt))
-        else:
-            trans_list_utc = []
-            trans_idx = []
-
-        # Read the ttinfo struct, (utoff, isdst, abbrind)
-        if typecnt:
-            utcoff, isdst, abbrind = zip(
-                *(struct.unpack(">lbb", fobj.read(6)) for i in range(typecnt))
-            )
-        else:
-            utcoff = ()
-            isdst = ()
-            abbrind = ()
-
-        # Now read the abbreviations. They are null-terminated strings, indexed
-        # not by position in the array but by position in the unsplit
-        # abbreviation string. I suppose this makes more sense in C, which uses
-        # null to terminate the strings, but it's inconvenient here...
-        char_total = 0
-        abbr_vals = {}
-        for abbr in fobj.read(charcnt).decode().split("\x00"):
-            abbr_vals[char_total] = abbr
-            char_total += len(abbr) + 1
-
-        abbr = [abbr_vals[idx] for idx in abbrind]
-
-        # The remainder of the file consists of leap seconds (currently unused) and
-        # the standard/wall and ut/local indicators, which are metadata we don't need.
-        # In version 2 files, we need to skip the unnecessary data to get at the TZ string:
-        if header.version >= 2:
-            # Each leap second record has size (time_size * 4)
-            skip_bytes = header.isutcnt + header.isstdcnt + header.leapcnt * 32
-            fobj.seek(skip_bytes, 1)
-
-            c = fobj.read(1)  # Should be \n
-            assert c == b"\n", c
-
-            tz_bytes = b""
-            # TODO: Walrus operator
-            while True:
-                c = fobj.read(1)
-                if c == b"\n":
-                    break
-                tz_bytes += c
-
-            tz_str = tz_bytes.decode()
-        else:
-            tz_str = None
-
-        return trans_idx, trans_list_utc, utcoff, isdst, abbr, tz_str
 
     @staticmethod
     def _utcoff_to_dstoff(trans_idx, utcoffsets, isdsts):
@@ -442,39 +352,6 @@ class ZoneInfo(tzinfo):
             trans_list_wall[1][i] += offset_1
 
         return trans_list_wall
-
-
-class _TZifHeader:
-    __slots__ = [
-        "version",
-        "isutcnt",
-        "isstdcnt",
-        "leapcnt",
-        "timecnt",
-        "typecnt",
-        "charcnt",
-    ]
-
-    def __init__(self, *args):
-        assert len(self.__slots__) == len(args)
-        for attr, val in zip(self.__slots__, args):
-            setattr(self, attr, val)
-
-    @classmethod
-    def from_file(cls, stream):
-        # The header starts with a 4-byte "magic" value
-        if stream.read(4) != b"TZif":
-            raise ValueError("Invalid TZif file: magic not found")
-
-        version = int(stream.read(1))
-        stream.read(15)
-
-        args = (version,)
-
-        # Slots are defined in the order that the bytes are arranged
-        args = args + struct.unpack(">6l", stream.read(24))
-
-        return cls(*args)
 
 
 class _ttinfo:

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -146,6 +146,17 @@ class ZoneInfoTest(TzPathUserMixin, unittest.TestCase):
         with self.subTest(name="from file without key"):
             self.assertRegex(repr(zi_ff_nk), class_name)
 
+    def test_bad_zones(self):
+        bad_zones = [
+            b"",  # Empty file
+            b"AAAA3" + b" " * 15,  # Bad magic
+        ]
+
+        for bad_zone in bad_zones:
+            fobj = io.BytesIO(bad_zone)
+            with self.assertRaises(ValueError):
+                ZoneInfo.from_file(fobj)
+
     def test_unambiguous(self):
         test_cases = []
         for key in self.zones():

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -791,6 +791,20 @@ class ZoneInfoPickleTest(TzPathUserMixin, unittest.TestCase):
         self.assertIs(zi, zi_rt_2)
 
 
+class TzPathTest(unittest.TestCase, TzPathUserMixin):
+    def test_tzpath_error(self):
+        bad_values = [
+            "/etc/zoneinfo:/usr/share/zoneinfo",
+            b"/etc/zoneinfo:/usr/share/zoneinfo",
+            0,
+        ]
+
+        for bad_value in bad_values:
+            with self.subTest(value=bad_value):
+                with self.assertRaises(TypeError):
+                    zoneinfo.set_tzpath(bad_value)
+
+
 @dataclasses.dataclass
 class ZoneOffset:
     tzname: str

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -58,7 +58,7 @@ def tearDownModule():
 def tzpath_context(tzpath, lock=TZPATH_LOCK):
     with lock:
         # TODO: Expose a public mechanism to get this information
-        old_path = zoneinfo._zoneinfo.TZPATH
+        old_path = zoneinfo._tzpath.TZPATH
         try:
             zoneinfo.set_tzpath(tzpath)
             yield


### PR DESCRIPTION
The tzpath-handling and file IO parts of the code base will be used by both the Python and C extension (at least initially), so they have been moved into their own dedicated private submodules.

To try and comply with 100% diff coverage, I've also gotten these modules to 100% code coverage, and in the process fixed a few other issues:

1. Zero-transition TZif files are now supported, and the TZStr tests have been refactored to take advantage of this.
2. `set_tzpath` now raises `TypeError` instead of `ValueError` if you pass it a string-like value.
3. Setting the `PYTHONTZPATH` variable to "" now correctly sets `TZPATH` to `()`
4. The `zoneinfo.TZPATH` variable is now exposed, using a `__getattr__` mechanism to ensure that it always points to `zoneinfo._tzpath.TZPATH`.