### PR TITLE
Add property tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docs/_build/
 # Testing
 .cache
 .hypothesis_cache
+.hypothesis
 .mypy_cache
 .pytest_cache
 .tox

--- a/src/zoneinfo/_common.py
+++ b/src/zoneinfo/_common.py
@@ -69,8 +69,8 @@ def load_data(fobj):
     # the standard/wall and ut/local indicators, which are metadata we don't need.
     # In version 2 files, we need to skip the unnecessary data to get at the TZ string:
     if header.version >= 2:
-        # Each leap second record has size (time_size * 4)
-        skip_bytes = header.isutcnt + header.isstdcnt + header.leapcnt * 32
+        # Each leap second record has size (time_size + 4)
+        skip_bytes = header.isutcnt + header.isstdcnt + header.leapcnt * 12
         fobj.seek(skip_bytes, 1)
 
         c = fobj.read(1)  # Should be \n

--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -257,7 +257,7 @@ class ZoneInfo(tzinfo):
                 self._tti_before = None
 
         # Set the "fallback" time zone
-        if tz_str is not None:
+        if tz_str is not None and tz_str != b"":
             self._tz_after = _parse_tz_str(tz_str.decode())
         else:
             self._tz_after = self._ttinfos[-1]

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1016,7 +1016,7 @@ class ZoneInfoPickleTest(TzPathUserMixin, unittest.TestCase):
         self.assertIs(zi, zi_rt_2)
 
 
-class TzPathTest(unittest.TestCase, TzPathUserMixin):
+class TzPathTest(TzPathUserMixin, unittest.TestCase):
     module = zoneinfo
 
     @staticmethod

--- a/tests/test_zoneinfo_property.py
+++ b/tests/test_zoneinfo_property.py
@@ -63,6 +63,15 @@ def valid_keys():
     return hypothesis.strategies.sampled_from(VALID_KEYS)
 
 
+class ZoneInfoTest(unittest.TestCase):
+    klass = zoneinfo.ZoneInfo
+
+    @hypothesis.given(key=valid_keys())
+    def test_str(self, key):
+        zi = self.klass(key)
+        self.assertEqual(str(zi), key)
+
+
 class ZoneInfoCacheTest(unittest.TestCase):
     klass = zoneinfo.ZoneInfo
 

--- a/tests/test_zoneinfo_property.py
+++ b/tests/test_zoneinfo_property.py
@@ -1,0 +1,81 @@
+import os
+import unittest
+from importlib import resources
+
+import hypothesis
+import pytest
+import zoneinfo
+
+
+def _valid_keys():
+    """Determine all valid ZoneInfo keys available on the search path.
+
+    A note of caution: This may attempt to open a large number of files.
+    """
+
+    valid_zones = set()
+
+    # Start with loading from the tzdata package if it exists: this has a
+    # pre-assembled list of zones that only requires opening one file.
+    try:
+        with resources.open_text("tzdata", "zones") as f:
+            for zone in f:
+                zone = zone.strip()
+                if zone:
+                    valid_zones.add(zone)
+    except (ImportError, FileNotFoundError):
+        pass
+
+    def valid_key(fpath):
+        try:
+            with open(fpath, "rb") as f:
+                return f.read(4) == b"TZif"
+        except Exception:  # pragma: nocover
+            pass
+
+    for tz_root in zoneinfo.TZPATH:
+        if not os.path.exists(tz_root):
+            continue
+
+        for root, _, files in os.walk(tz_root):
+            for file in files:
+                fpath = os.path.join(root, file)
+
+                key = os.path.relpath(fpath, start=tz_root)
+                if os.sep != "/":  # pragma: nocover
+                    key = key.replace(os.sep, "/")
+
+                if not key or key in valid_zones:
+                    continue
+
+                if valid_key(fpath):
+                    valid_zones.add(key)
+
+    return sorted(valid_zones)
+
+
+VALID_KEYS = _valid_keys()
+if not VALID_KEYS:
+    pytest.skip("No time zone data available", allow_module_level=True)
+
+
+def valid_keys():
+    return hypothesis.strategies.sampled_from(VALID_KEYS)
+
+
+class ZoneInfoCacheTest(unittest.TestCase):
+    klass = zoneinfo.ZoneInfo
+
+    @hypothesis.given(key=valid_keys())
+    def test_cache(self, key):
+        zi_0 = self.klass(key)
+        zi_1 = self.klass(key)
+
+        self.assertIs(zi_0, zi_1)
+
+    @hypothesis.given(key=valid_keys())
+    def test_nocache(self, key):
+        zi_0 = self.klass.nocache(key)
+        zi_1 = self.klass.nocache(key)
+
+        self.assertIsNot(zi_0, zi_1)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skip_missing_interpreters = true
 description = Run the tests
 deps =
     coverage[toml]
+    hypothesis>=5.7.0
     pytest
     pytest-cov
     pytest-subtests


### PR DESCRIPTION
This adds some basic property tests to the repository - this doesn't yet cover any of the behaviors of the ZoneInfo file such as `fromutc` or whatnot.

Eventually we may want to refactor some of the utilities in `test_zoneinfo.py` into a common file, but for now I'd prefer to leave them in `test_zoneinfo` since it's not yet clear if the hypothesis tests will be able to make the transition to the standard library.

The seemingly unrelated changes come from bugs that are immediately revealed from trying to construct arbitrary ZoneInfo files.

@Zac-HD - Do you mind giving this a review? Once this project gets migrated into the standard library, we may want to migrate these tests into Zac-HD/stdlib-property-tests.