### PR TITLE
Separate tests and coverage upload.

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,6 +28,8 @@ jobs:
     - name: Run tests
       run: |
         tox
+    - name: Report coverage
+      run: |
         tox -e coverage-report,codecov
 
   other:


### PR DESCRIPTION
Without this, sometimes the Windows jobs will fail but still report success.