### PR TITLE
Move tzdata loader into _common and fix tests

### DIFF
--- a/src/zoneinfo/_common.py
+++ b/src/zoneinfo/_common.py
@@ -1,6 +1,20 @@
 import struct
 
 
+def load_tzdata(key):
+    import importlib.resources
+
+    # TODO: Proper error for malformed keys?
+    components = key.split("/")
+    package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
+    resource_name = components[-1]
+
+    try:
+        return importlib.resources.open_binary(package_name, resource_name)
+    except (ImportError, FileNotFoundError) as e:
+        raise ValueError(f"No time zone found with key {key}") from e
+
+
 def load_data(fobj):
     header = _TZifHeader.from_file(fobj)
 

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -322,6 +322,11 @@ class TZDataTests(ZoneInfoTest):
     in the event that the time zone policies in the relevant time zones change.
     """
 
+    def setUp(self):
+        super().setUp()
+
+        self.klass.clear_cache()
+
     @property
     def tzpath(self):
         return []


### PR DESCRIPTION
The biggest issue here is that it seems the TZData tests never "worked" properly because they were almost always hitting the cache, which was populated in earlier tests using the same keys. This was determined when the C extension was failing for the property tests but not the `TZDataTest` tests, and it seems important enough to "backport" it to the master branch before the C extension is ready.

This also moves `_load_tzdata` into a `_common` module, rather than trying to duplicate this logic in C, which wouldn't be so hard but it would likely be tedious.