### PR TITLE
Specify empty TZ string behavior and add more tests

### DIFF
--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -247,7 +247,13 @@ class ZoneInfo(tzinfo):
         if tz_str is not None and tz_str != b"":
             self._tz_after = _parse_tz_str(tz_str.decode())
         else:
-            self._tz_after = self._ttinfos[-1]
+            if not self._ttinfos and not _ttinfo_list:
+                raise ValueError("No time zone information found.")
+
+            if self._ttinfos:
+                self._tz_after = self._ttinfos[-1]
+            else:
+                self._tz_after = _ttinfo_list[-1]
 
     @staticmethod
     def _utcoff_to_dstoff(trans_idx, utcoffsets, isdsts):

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -849,6 +849,29 @@ class TZStrTest(unittest.TestCase):
                 (datetime(2020, 12, 31, 23, 59, 59, 999999), AAA, NORMAL),
             )
 
+        @call
+        def _add():
+            # Taken from America/Godthab, this rule has a transition on the
+            # Saturday before the last Sunday of March and October, at 22:00
+            # and 23:00, respectively. This is encoded with negative start
+            # and end transition times.
+            tzstr = "<-03>3<-02>,M3.5.0/-2,M10.5.0/-1"
+
+            N03 = ZoneOffset("-03", timedelta(hours=-3))
+            N02 = ZoneOffset("-02", timedelta(hours=-2), ONE_H)
+
+            cases[tzstr] = (
+                (datetime(2020, 3, 27), N03, NORMAL),
+                (datetime(2020, 3, 28, 21, 59, 59), N03, NORMAL),
+                (datetime(2020, 3, 28, 22, fold=0), N03, GAP),
+                (datetime(2020, 3, 28, 22, fold=1), N02, GAP),
+                (datetime(2020, 3, 28, 23), N02, NORMAL),
+                (datetime(2020, 10, 24, 21), N02, NORMAL),
+                (datetime(2020, 10, 24, 22, fold=0), N02, FOLD),
+                (datetime(2020, 10, 24, 22, fold=1), N03, FOLD),
+                (datetime(2020, 10, 24, 23), N03, NORMAL),
+            )
+
         cls.test_cases = cases
 
 

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -684,6 +684,8 @@ class TZStrTest(unittest.TestCase):
             "PST8PDT",  # DST but no transition specified
             "+11",  # Unquoted alphanumeric
             "GMT,M3.2.0/2,M11.1.0/3",  # Transition rule but no DST
+            "GMT0+11,M3.2.0/2,M11.1.0/3",  # Unquoted alphanumeric in DST
+            "PST8PDT,M3.2.0/2",  # Only one transition rule
             # Invalid offsets
             "STD+25",
             "STD-25",

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -872,6 +872,25 @@ class TZStrTest(unittest.TestCase):
                 (datetime(2020, 10, 24, 23), N03, NORMAL),
             )
 
+        @call
+        def _add():
+            # Transition times with minutes and seconds
+            tzstr = "AAA3BBB,M3.2.0/01:30,M11.1.0/02:15:45"
+
+            AAA = ZoneOffset("AAA", timedelta(hours=-3))
+            BBB = ZoneOffset("BBB", timedelta(hours=-2), ONE_H)
+
+            cases[tzstr] = (
+                (datetime(2012, 3, 11, 1, 0), AAA, NORMAL),
+                (datetime(2012, 3, 11, 1, 30, fold=0), AAA, GAP),
+                (datetime(2012, 3, 11, 1, 30, fold=1), BBB, GAP),
+                (datetime(2012, 3, 11, 2, 30), BBB, NORMAL),
+                (datetime(2012, 11, 4, 1, 15, 44, 999999), BBB, NORMAL),
+                (datetime(2012, 11, 4, 1, 15, 45, fold=0), BBB, FOLD),
+                (datetime(2012, 11, 4, 1, 15, 45, fold=1), AAA, FOLD),
+                (datetime(2012, 11, 4, 2, 15, 45), AAA, NORMAL),
+            )
+
         cls.test_cases = cases
 
 


### PR DESCRIPTION
Some Version 2+ files have empty TZ strings, which means that the behavior after the last transition is undefined. For now, we will fall back to "hold the last active value", though "use the last STD value" would also be a reasonable and valid choice. In practice, these may not be terribly different.

This also adds a few more tests to round out both types of invalid TZ string and a few more types of *valid* TZ string.