### PR TITLE
Support TZif\0 instead of TZif1

### DIFF
--- a/src/zoneinfo/_common.py
+++ b/src/zoneinfo/_common.py
@@ -142,7 +142,11 @@ class _TZifHeader:
         if stream.read(4) != b"TZif":
             raise ValueError("Invalid TZif file: magic not found")
 
-        version = int(stream.read(1))
+        _version = stream.read(1)
+        if _version == b"\x00":
+            version = 1
+        else:
+            version = int(_version)
         stream.read(15)
 
         args = (version,)

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1192,7 +1192,7 @@ class ZoneInfoData:
 
         header_start = 4 + 16
         header_end = header_start + 24  # 6l == 24 bytes
-        assert version != 1, "Version 1 file found: no conversion necessary"
+        assert version >= 2, "Version 1 file found: no conversion necessary"
         isutcnt, isstdcnt, leapcnt, timecnt, typecnt, charcnt = struct.unpack(
             ">6l", contents[header_start:header_end]
         )
@@ -1206,7 +1206,7 @@ class ZoneInfoData:
             + isutcnt
         )
         file_size += header_end
-        out = b"TZif" + b"1" + contents[5:file_size]
+        out = b"TZif" + b"\x00" + contents[5:file_size]
 
         assert (
             contents[file_size : (file_size + 4)] == b"TZif"


### PR DESCRIPTION
According to RFC 8536 §3.1, the version indicator for version 1 files is '\0' (0x00) (NUL), rather than '1' (0x31) — which makes sense, since the version number was likely added using one of the reserved header bytes.

This version of the code will support `0x00` and also any erroneous files with `TZif1` as the header (though it appears that there was never a version of zic that would generate files with that version number).