### PR TITLE
Make test dataclasses frozen

### DIFF
--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1233,14 +1233,14 @@ class TestModule(unittest.TestCase):
         self.assertCountEqual(module_dir, module_unique)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class ZoneOffset:
     tzname: str
     utcoffset: timedelta
     dst: timedelta = ZERO
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class ZoneTransition:
     transition: datetime
     offset_before: ZoneOffset


### PR DESCRIPTION
These are basically stored as global singletons, so it is not prudent to have them also be mutable.