### PR TITLE
Configure isort to be compatible with black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,11 @@ source = ["src", ".tox/*/site-packages"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+
+[tool.isort]
+atomic=true
+force_grid_wrap=0
+include_trailing_comma=true
+multi_line_output=3
+not_skip="__init__.py"
+use_parentheses=true

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     isort
 commands =
     black .
-    isort --atomic -rc scripts src tests
+    isort -rc scripts src tests
 
 [testenv:lint]
 description = Run linting checks


### PR DESCRIPTION
One of the main inconsistencies with black is the multi-line output, so black will try to write:

```python
from module import (
  x,
  y,
  z,
)
```

But isort will try to write:

```python
from module import x, y, z
```

This makes it impossible to pass `--check` with both tools.

I've also included a few other changes to the isort configuration that were mostly stolen from the attrs project.