### PR TITLE
Eagerly import _tzpath in zoneinfo module

### DIFF
--- a/src/zoneinfo/__init__.py
+++ b/src/zoneinfo/__init__.py
@@ -1,14 +1,14 @@
 __all__ = ["ZoneInfo", "set_tzpath", "TZPATH"]
 
-from ._tzpath import set_tzpath
+from . import _tzpath
 from ._version import __version__
 from ._zoneinfo import ZoneInfo
+
+set_tzpath = _tzpath.set_tzpath
 
 
 def __getattr__(name):
     if name == "TZPATH":
-        from . import _tzpath
-
         return _tzpath.TZPATH
     else:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
If we import zoneinfo._tzpath on demand, there's the possibility that some import trickery means that `set_tzpath` for this instance of the zoneinfo module points to a different `_tzpath` module than the one we get from a fresh import. Best to make the module self-contained.