### PR TITLE
Add "consistency" property tests

### DIFF
--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -382,8 +382,8 @@ zoneinfo_clear_cache(PyObject *cls, PyObject *args, PyObject *kwargs)
         }
 
         while ((item = PyIter_Next(iter))) {
-            PyObject *tmp = PyObject_CallMethodObjArgs(weak_cache, pop,
-                                                       item, Py_None, NULL);
+            PyObject *tmp = PyObject_CallMethodObjArgs(weak_cache, pop, item,
+                                                       Py_None, NULL);
 
             Py_DECREF(item);
             if (tmp == NULL) {

--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -144,7 +144,7 @@ class ZoneInfo(tzinfo):
 
             # Detect fold
             shift = tti_prev.utcoff - tti.utcoff
-            fold = shift > timedelta(0, timestamp - self._trans_utc[idx - 1])
+            fold = shift.total_seconds() > timestamp - self._trans_utc[idx - 1]
         dt += tti.utcoff
         if fold:
             return dt.replace(fold=1)


### PR DESCRIPTION
This is one of those helpful situations where we have two implementations of the same logic that should have exactly the same result, so we can feed it any arbitrary input and test that the two are consistent.

@Zac-HD This might be useful to mention in your language summit presentation. If `test.support.import_fresh_module` were less touchy, I'd be all over this for `datetime`, and this whole class of tests is super useful for anything with both a C and Python implementation, for PEP 399 compliance. That includes, I believe, `heapq`, `json` and `warnings`, plus any new modules that have a C extension.