### PR TITLE
Rename methods to be consistent with PEP

### DIFF
--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -333,7 +333,7 @@ error:
 }
 
 static PyObject *
-zoneinfo_nocache(PyTypeObject *cls, PyObject *args, PyObject *kwargs)
+zoneinfo_no_cache(PyTypeObject *cls, PyObject *args, PyObject *kwargs)
 {
     static char *kwlist[] = {"key", NULL};
     PyObject *key = NULL;
@@ -2182,7 +2182,7 @@ static PyMethodDef zoneinfo_methods[] = {
     {"clear_cache", (PyCFunction)zoneinfo_clear_cache,
      METH_VARARGS | METH_KEYWORDS | METH_CLASS,
      PyDoc_STR("Clear the ZoneInfo cache.")},
-    {"nocache", (PyCFunction)zoneinfo_nocache,
+    {"no_cache", (PyCFunction)zoneinfo_no_cache,
      METH_VARARGS | METH_KEYWORDS | METH_CLASS,
      PyDoc_STR("Get a new instance of ZoneInfo, bypassing the cache.")},
     {"from_file", (PyCFunction)zoneinfo_from_file,

--- a/src/zoneinfo/__init__.py
+++ b/src/zoneinfo/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["ZoneInfo", "set_tzpath", "TZPATH"]
+__all__ = ["ZoneInfo", "reset_tzpath", "TZPATH"]
 
 from . import _tzpath
 from ._version import __version__
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from ._zoneinfo import ZoneInfo
 
-set_tzpath = _tzpath.set_tzpath
+reset_tzpath = _tzpath.reset_tzpath
 
 
 def __getattr__(name):

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -2,8 +2,10 @@ import os
 import sys
 
 
-def set_tzpath(tzpaths=None):
+def reset_tzpath(to=None):
     global TZPATH
+
+    tzpaths = to
     if tzpaths is not None:
         if isinstance(tzpaths, (str, bytes)):
             raise TypeError(
@@ -44,4 +46,4 @@ def find_tzfile(key):
 
 
 TZPATH = ()
-set_tzpath()
+reset_tzpath()

--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -51,7 +51,7 @@ class ZoneInfo(tzinfo):
         return instance
 
     @classmethod
-    def nocache(cls, key):
+    def no_cache(cls, key):
         obj = cls._new_instance(key)
         obj._from_cache = False
 
@@ -207,7 +207,7 @@ class ZoneInfo(tzinfo):
         if from_cache:
             return cls(key)
         else:
-            return cls.nocache(key)
+            return cls.no_cache(key)
 
     def _find_tzfile(self, key):
         return _tzpath.find_tzfile(key)

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -54,7 +54,7 @@ class ZoneInfoTestBase(unittest.TestCase):
         with lock:
             old_path = self.module.TZPATH
             try:
-                self.module.set_tzpath(tzpath)
+                self.module.reset_tzpath(tzpath)
                 yield
             finally:
-                self.module.set_tzpath(old_path)
+                self.module.reset_tzpath(old_path)

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -69,10 +69,10 @@ class ZoneInfoTestBase(unittest.TestCase):
         with lock:
             old_path = self.module.TZPATH
             try:
-                self.module.set_tzpath(tzpath)
+                self.module.reset_tzpath(tzpath)
                 yield
             finally:
-                self.module.set_tzpath(old_path)
+                self.module.reset_tzpath(old_path)
 
 
 class TzPathUserMixin:
@@ -1223,7 +1223,7 @@ class ZoneInfoCacheTest(TzPathUserMixin, ZoneInfoTestBase):
 
         self.assertIsNot(tz0, tz1)
 
-    def test_cache_set_tzpath(self):
+    def test_cache_reset_tzpath(self):
         """Test that the cache persists when tzpath has been changed.
 
         The PEP specifies that as long as a reference exists to one zone
@@ -1402,7 +1402,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
                 os.environ[path_var] = old_env  # pragma: nocover
 
     def test_env_variable(self):
-        """Tests that the environment variable works with set_tzpath"""
+        """Tests that the environment variable works with reset_tzpath."""
         new_paths = [
             ("", []),
             ("/etc/zoneinfo", ["/etc/zoneinfo"]),
@@ -1412,9 +1412,14 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
         for new_path_var, expected_result in new_paths:
             with self.python_tzpath_context(new_path_var):
                 with self.subTest(tzpath=new_path_var):
-                    self.module.set_tzpath()
+                    self.module.reset_tzpath()
                     tzpath = self.module.TZPATH
                     self.assertSequenceEqual(tzpath, expected_result)
+
+    def test_reset_tzpath_kwarg(self):
+        self.module.reset_tzpath(to=["/a/b/c"])
+
+        self.assertSequenceEqual(self.module.TZPATH, ("/a/b/c",))
 
     def test_tzpath_error(self):
         bad_values = [
@@ -1426,7 +1431,7 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
         for bad_value in bad_values:
             with self.subTest(value=bad_value):
                 with self.assertRaises(TypeError):
-                    self.module.set_tzpath(bad_value)
+                    self.module.reset_tzpath(bad_value)
 
     def test_tzpath_attribute(self):
         tzpath_0 = ["/one", "/two"]

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1216,10 +1216,10 @@ class ZoneInfoCacheTest(TzPathUserMixin, ZoneInfoTestBase):
 
         self.assertIs(tz0, tz1)
 
-    def test_nocache(self):
+    def test_no_cache(self):
 
         tz0 = self.klass("Europe/Lisbon")
-        tz1 = self.klass.nocache("Europe/Lisbon")
+        tz1 = self.klass.no_cache("Europe/Lisbon")
 
         self.assertIsNot(tz0, tz1)
 
@@ -1317,14 +1317,14 @@ class ZoneInfoPickleTest(TzPathUserMixin, ZoneInfoTestBase):
 
         self.assertIs(zi_rt, zi_rt2)
 
-    def test_nocache(self):
-        zi_nocache = self.klass.nocache("Europe/Dublin")
+    def test_no_cache(self):
+        zi_no_cache = self.klass.no_cache("Europe/Dublin")
 
-        pkl = pickle.dumps(zi_nocache)
+        pkl = pickle.dumps(zi_no_cache)
         zi_rt = pickle.loads(pkl)
 
         with self.subTest(test="Not the pickled object"):
-            self.assertIsNot(zi_rt, zi_nocache)
+            self.assertIsNot(zi_rt, zi_no_cache)
 
         zi_rt2 = pickle.loads(pkl)
         with self.subTest(test="Not a second unpickled object"):

--- a/tests/test_zoneinfo_property.py
+++ b/tests/test_zoneinfo_property.py
@@ -103,8 +103,8 @@ class ZoneInfoPickleTest(ZoneInfoTestBase):
         self.assertIs(zi, zi_rt)
 
     @hypothesis.given(key=valid_keys())
-    def test_pickle_unpickle_nocache(self, key):
-        zi = self.klass.nocache(key)
+    def test_pickle_unpickle_no_cache(self, key):
+        zi = self.klass.no_cache(key)
         pkl_str = pickle.dumps(zi)
         zi_rt = pickle.loads(pkl_str)
 
@@ -129,11 +129,11 @@ class ZoneInfoPickleTest(ZoneInfoTestBase):
         self.assertIs(zi_1, zi_2)
 
     @hypothesis.given(key=valid_keys())
-    def test_pickle_unpickle_nocache_multiple_rounds(self, key):
+    def test_pickle_unpickle_no_cache_multiple_rounds(self, key):
         """Test that pickle/unpickle is idempotent."""
         zi_cache = self.klass(key)
 
-        zi_0 = self.klass.nocache(key)
+        zi_0 = self.klass.no_cache(key)
         pkl_str_0 = pickle.dumps(zi_0)
         zi_1 = pickle.loads(pkl_str_0)
         pkl_str_1 = pickle.dumps(zi_1)
@@ -167,9 +167,9 @@ class ZoneInfoCacheTest(ZoneInfoTestBase):
         self.assertIs(zi_0, zi_1)
 
     @hypothesis.given(key=valid_keys())
-    def test_nocache(self, key):
-        zi_0 = self.klass.nocache(key)
-        zi_1 = self.klass.nocache(key)
+    def test_no_cache(self, key):
+        zi_0 = self.klass.no_cache(key)
+        zi_1 = self.klass.no_cache(key)
 
         self.assertIsNot(zi_0, zi_1)
 


### PR DESCRIPTION
These names were changed in the PEP, but hadn't been updated in the implementation yet.

Closes #31.