### PR TITLE
Move the Python.h declaration to the top.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ IndentWidth: 4
 Language: Cpp
 PointerAlignment: Right
 ReflowComments: true
+SortIncludes: false
 SpaceBeforeParens: ControlStatements
 SpacesInParentheses: false
 TabWidth: 4

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -1,8 +1,9 @@
+#include "Python.h"
+
 #include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include "Python.h"
 #include "datetime.h"
 
 // Imports


### PR DESCRIPTION
This is apparently required on AIX:
https://github.com/pganssle/zoneinfo/issues/37

Apparently the previous `.clang-format` file was enforcing that "Python.h" go after the standard library headers, so I've turned off include sorting.

@isidentical Do you have access to an AIX system? Would you mind checking that this has fixed the problem?

Fixes #37.