### PR TITLE
Start testing in random order (and fixes to allow this)

### DIFF
--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -132,6 +132,13 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
     module = py_zoneinfo
     class_name = "ZoneInfo"
 
+    def setUp(self):
+        super().setUp()
+
+        # This is necessary because various subclasses pull from different
+        # data sources (e.g. tzdata, V1 files, etc).
+        self.klass.clear_cache()
+
     @property
     def tzpath(self):
         return [ZONEINFO_DATA.tzpath]
@@ -449,11 +456,6 @@ class TZDataTests(ZoneInfoTest):
     some of the tests (particularly those related to the far future) may break
     in the event that the time zone policies in the relevant time zones change.
     """
-
-    def setUp(self):
-        super().setUp()
-
-        self.klass.clear_cache()
 
     @property
     def tzpath(self):

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -394,6 +394,8 @@ class CZoneInfoDatetimeSubclassTest(DatetimeSubclassMixin, CZoneInfoTest):
 class ZoneInfoTestSubclass(ZoneInfoTest):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
+
         class ZISubclass(cls.klass):
             pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ deps =
     hypothesis>=5.7.0
     pytest
     pytest-cov
+    pytest-randomly
     pytest-subtests
+    pytest-xdist
 extras =
     {env:TEST_EXTRAS_TOX:}
 setenv =


### PR DESCRIPTION
Using the [`pytest-randomly`](https://github.com/pytest-dev/pytest-randomly) plugin allows us to run the tests in a random order, to avoid accidental dependencies on the run order of the tests.

As part of adding this to the test suite, I ran the test suite several hundred times and fixed all the issues that cropped up. Likely we will want to follow this up with a CI job that just runs the test suite a few hundred times once a day or once a week or so.

This also adds `pytest-xdist`, which runs the tests in parallel. It's not enabled on CI at the moment, but it does speed things up a bit when running the tests over and over again in a loop.