### PR TITLE
Add time support

### DIFF
--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1618,9 +1618,6 @@ class ZoneDumpData:
     def load_transition_examples(cls, key):
         return cls._get_zonedump()[key]
 
-    # These are examples of a bunch of transitions that can be used in tests
-    # The format for each transition is:
-    #
     @classmethod
     def _get_zonedump(cls):
         if not cls._ZONEDUMP_DATA:

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -251,6 +251,14 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                 with self.assertRaises(exc_type):
                     zone.fromutc(val)
 
+    def test_utc(self):
+        zi = self.klass("UTC")
+        dt = datetime(2020, 1, 1, tzinfo=zi)
+
+        self.assertEqual(dt.utcoffset(), ZERO)
+        self.assertEqual(dt.dst(), ZERO)
+        self.assertEqual(dt.tzname(), "UTC")
+
     def test_unambiguous(self):
         test_cases = []
         for key in self.zones():

--- a/tests/test_zoneinfo_property.py
+++ b/tests/test_zoneinfo_property.py
@@ -17,6 +17,7 @@ py_zoneinfo, c_zoneinfo = test_support.get_modules()
 UTC = datetime.timezone.utc
 MIN_UTC = datetime.datetime.min.replace(tzinfo=UTC)
 MAX_UTC = datetime.datetime.max.replace(tzinfo=UTC)
+ZERO = datetime.timedelta(0)
 
 
 def _valid_keys():
@@ -82,6 +83,19 @@ class ZoneInfoTest(ZoneInfoTestBase):
     def test_str(self, key):
         zi = self.klass(key)
         self.assertEqual(str(zi), key)
+
+    @hypothesis.given(
+        dt=hypothesis.strategies.one_of(
+            hypothesis.strategies.datetimes(), hypothesis.strategies.times()
+        )
+    )
+    def test_utc(self, dt):
+        zi = self.klass("UTC")
+        dt_zi = dt.replace(tzinfo=zi)
+
+        self.assertEqual(dt_zi.utcoffset(), ZERO)
+        self.assertEqual(dt_zi.dst(), ZERO)
+        self.assertEqual(dt_zi.tzname(), "UTC")
 
 
 class CZoneInfoTest(ZoneInfoTest):


### PR DESCRIPTION
Per the documentation, `.utcoffset()`, `.dst()` and `.tzname()` should return None when the offset is unknown; for anything with transitions, a datetime.time() is not enough information to resolve the offset.

For fixed offset zones, we know the right response - though I believe this will not correctly handle a "permanent DST" zone like "XST0XDT,0/0,J365/25", which looks like it has transitions but doesn't.

Luckily, that sort of thing doesn't exist in the time zone database, and even if it were added "can't get the offset from datetime.time" is not a big deal.

Closes #33 and #34.