### PR TITLE
Handle relative paths in TZPATH

### DIFF
--- a/src/zoneinfo/__init__.py
+++ b/src/zoneinfo/__init__.py
@@ -1,4 +1,10 @@
-__all__ = ["ZoneInfo", "reset_tzpath", "TZPATH", "ZoneInfoNotFoundError"]
+__all__ = [
+    "ZoneInfo",
+    "reset_tzpath",
+    "TZPATH",
+    "ZoneInfoNotFoundError",
+    "InvalidTZPathWarning",
+]
 
 from . import _tzpath
 from ._common import ZoneInfoNotFoundError
@@ -10,6 +16,7 @@ except ImportError:
     from ._zoneinfo import ZoneInfo
 
 reset_tzpath = _tzpath.reset_tzpath
+InvalidTZPathWarning = _tzpath.InvalidTZPathWarning
 
 
 def __getattr__(name):

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -12,14 +12,13 @@ def reset_tzpath(to=None):
                 f"tzpaths must be a list or tuple, "
                 + f"not {type(tzpaths)}: {tzpaths}"
             )
+        elif not all(map(os.path.isabs, tzpaths)):
+            raise ValueError(_get_invalid_paths_message(tzpaths))
         base_tzpath = tzpaths
     else:
-        if "PYTHONTZPATH" in os.environ:
-            env_var = os.environ["PYTHONTZPATH"]
-            if env_var:
-                base_tzpath = env_var.split(os.pathsep)
-            else:
-                base_tzpath = ()
+        env_var = os.environ.get("PYTHONTZPATH", None)
+        if env_var is not None:
+            base_tzpath = _parse_python_tzpath(env_var)
         elif sys.platform != "win32":
             base_tzpath = [
                 "/usr/share/zoneinfo",
@@ -35,9 +34,43 @@ def reset_tzpath(to=None):
     TZPATH = tuple(base_tzpath)
 
 
+def _parse_python_tzpath(env_var):
+    if not env_var:
+        return ()
+    else:
+        raw_tzpath = env_var.split(os.pathsep)
+        new_tzpath = tuple(filter(os.path.isabs, raw_tzpath))
+
+        # If anything has been filtered out, we will warn about it
+        if len(new_tzpath) != len(raw_tzpath):
+            import warnings
+
+            msg = _get_invalid_paths_message(raw_tzpath)
+
+            warnings.warn(
+                "Invalid paths specified in PYTHONTZPATH environment variable."
+                + msg,
+                InvalidTZPathWarning,
+            )
+
+        return new_tzpath
+
+
+def _get_invalid_paths_message(tzpaths):
+    invalid_paths = (path for path in tzpaths if not os.path.isabs(path))
+
+    prefix = "\n    "
+    indented_str = prefix + prefix.join(invalid_paths)
+
+    return (
+        "Paths should be absolute but found the following relative paths:"
+        + indented_str
+    )
+
+
 def find_tzfile(key):
     """Retrieve the path to a TZif file from a key."""
-    _validate_path(key)
+    _validate_tzfile_path(key)
     for search_path in TZPATH:
         filepath = os.path.join(search_path, key)
         if os.path.isfile(filepath):
@@ -49,7 +82,7 @@ def find_tzfile(key):
 _TEST_PATH = os.path.normpath(os.path.join("_", "_"))[:-1]
 
 
-def _validate_path(path, _base=_TEST_PATH):
+def _validate_tzfile_path(path, _base=_TEST_PATH):
     if os.path.isabs(path):
         raise ValueError(
             f"ZoneInfo keys may not be absolute paths, got: {path}"
@@ -73,6 +106,10 @@ def _validate_path(path, _base=_TEST_PATH):
 
 
 del _TEST_PATH
+
+
+class InvalidTZPathWarning(RuntimeWarning):
+    """Warning raised if an invalid path is specified in PYTHONTZPATH."""
 
 
 TZPATH = ()


### PR DESCRIPTION
Per PEP 615, only absolute paths are allowed in TZPATH; the behavior is up to the implementation, but it must either ignore, warn + ignore or raise.

We choose to warn for the environment variable and raise for `reset_tzpath(to=...)`.

This is related to / the inverse of #44.