### PR TITLE
Update tzdata link to new home

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,4 +34,4 @@ where=src
 
 [options.extras_require]
 tzdata =
-    tzdata @ git+https://github.com/pganssle/tzdata.git
+    tzdata @ git+https://github.com/python/tzdata.git


### PR DESCRIPTION
tzdata has moved into the python organization, so until we make a release, the extra needs to point at the tzdata repo.