### PR TITLE
Add setup.cfg formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
 
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.9.0
+    hooks:
+    -   id: setup-cfg-fmt
+
   - repo: https://github.com/doublify/pre-commit-clang-format
     rev: f4c4ac5948aff384af2b439bfabb2bdd65d2b3ac
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,34 +4,35 @@ version = attr:zoneinfo._version.__version__
 description = Backport of the standard library zoneinfo module
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = Apache-2.0
-license_files =
-    LICENSE
-    licenses/LICENSE_APACHE
 url = https://github.com/python/cpython
 author = Python Software Foundation
 author_email = datetime-sig@python.org
-project_urls =
-    Bug Reports = https://bugs.python.org
-    Source = https://github.com/python/cpython
+license = Apache-2.0
+license_file = LICENSE
+license_files =
+    LICENSE
+    licenses/LICENSE_APACHE
 classifiers =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
+project_urls =
+    Bug Reports = https://bugs.python.org
+    Source = https://github.com/python/cpython
 
 [options]
 packages = find:
-package_dir=
-    =src
 python_requires = >=3.8
 include_package_data = True
-
-[options.packages.find]
-where=src
+package_dir =
+    =src
 
 [options.extras_require]
 tzdata =
     tzdata @ git+https://github.com/python/tzdata.git
+
+[options.packages.find]
+where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ license_files =
     LICENSE
     licenses/LICENSE_APACHE
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3


### PR DESCRIPTION
This is not currently added to the GHA or to `tox -e format`, but I have been so spoiled by auto-formatters that I really don't want to have to think about consistent formatting anymore.