### PR TITLE
Backport changes from CPython PR

### DIFF
--- a/docs/zoneinfo.rst
+++ b/docs/zoneinfo.rst
@@ -121,11 +121,18 @@ Compile-time configuration
 
 The default :data:`TZPATH` includes several common deployment locations for the
 time zone database (except on Windows, where there are no "well-known"
-locations for time zone data). Downstream distributors and those building
-Python from source who know where their system time zone data is deployed may
-change the default time zone path by specifying the compile-time option
-``PYTHONTZPATHDEFAULT``, which should be a string delimited by
-:data:`os.pathsep`.
+locations for time zone data). On POSIX systems, downstream distributors and
+those building Python from source who know where their system
+time zone data is deployed may change the default time zone path by specifying
+the compile-time option ``TZPATH`` (or, more likely, the ``configure`` flag
+``--with-tzpath``), which should be a string delimited by :data:`os.pathsep`.
+
+On all platforms, the configured value is available as the ``TZPATH`` key in
+:func:`sysconfig.get_config_var`.
+
+.. note::
+
+    This option is currently not available in the backport.
 
 .. _zoneinfo_data_environment_var:
 

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -8,9 +8,9 @@
 #include "datetime.h"
 
 // Imports
-PyObject *io_open = NULL;
-PyObject *_tzpath_find_tzfile = NULL;
-PyObject *_common_mod = NULL;
+static PyObject *io_open = NULL;
+static PyObject *_tzpath_find_tzfile = NULL;
+static PyObject *_common_mod = NULL;
 
 typedef struct TransitionRuleType TransitionRuleType;
 typedef struct StrongCacheNode StrongCacheNode;

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -270,6 +270,7 @@ zoneinfo_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     }
 
     if (instance == Py_None) {
+        Py_DECREF(instance);
         PyObject *tmp = zoneinfo_new_instance(type, key);
         if (tmp == NULL) {
             return NULL;

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -845,7 +845,14 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     size_t ttinfos_allocated = 0;
 
     data_tuple = PyObject_CallMethod(_common_mod, "load_data", "O", file_obj);
+
     if (data_tuple == NULL) {
+        goto error;
+    }
+
+    if (!PyTuple_CheckExact(data_tuple)) {
+        PyErr_Format(PyExc_TypeError, "Invalid data result type: %r",
+                     data_tuple);
         goto error;
     }
 

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -2551,11 +2551,11 @@ static PyMethodDef zoneinfo_methods[] = {
 };
 
 static PyMemberDef zoneinfo_members[] = {
-    {"key",                              /* name */
-     offsetof(PyZoneInfo_ZoneInfo, key), /* offset */
-     T_OBJECT_EX,                        /* type */
-     READONLY,                           /* flags */
-     NULL /* docstring */},
+    {.name = "key",
+     .offset = offsetof(PyZoneInfo_ZoneInfo, key),
+     .type = T_OBJECT_EX,
+     .flags = READONLY,
+     .doc = NULL},
     {NULL}, /* Sentinel */
 };
 

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -186,6 +186,7 @@ zoneinfo_new_instance(PyTypeObject *type, PyObject *key)
     else if (file_path == Py_None) {
         file_obj = PyObject_CallMethod(_common_mod, "load_tzdata", "O", key);
         if (file_obj == NULL) {
+            Py_DECREF(file_path);
             return NULL;
         }
     }
@@ -223,7 +224,8 @@ error:
     self = NULL;
 cleanup:
     if (file_obj != NULL) {
-        PyObject_CallMethod(file_obj, "close", NULL);
+        PyObject *tmp = PyObject_CallMethod(file_obj, "close", NULL);
+        Py_DECREF(tmp);
         Py_DECREF(file_obj);
     }
     Py_DECREF(file_path);
@@ -322,6 +324,8 @@ zoneinfo_dealloc(PyObject *obj_self)
 
     Py_XDECREF(self->key);
     Py_XDECREF(self->file_repr);
+
+    Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static PyObject *

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -574,20 +574,17 @@ zoneinfo_fromutc(PyObject *obj_self, PyObject *dt)
             PyObject *replace = PyObject_GetAttrString(tmp, "replace");
             PyObject *args = PyTuple_New(0);
             PyObject *kwargs = PyDict_New();
-            PyObject *one = PyLong_FromLong(1);
 
             Py_DECREF(tmp);
-            if (args == NULL || kwargs == NULL || replace == NULL ||
-                one == NULL) {
+            if (args == NULL || kwargs == NULL || replace == NULL) {
                 Py_XDECREF(args);
                 Py_XDECREF(kwargs);
                 Py_XDECREF(replace);
-                Py_XDECREF(one);
                 return NULL;
             }
 
             dt = NULL;
-            if (!PyDict_SetItemString(kwargs, "fold", one)) {
+            if (!PyDict_SetItemString(kwargs, "fold", _PyLong_One)) {
                 dt = PyObject_Call(replace, args, kwargs);
             }
 

--- a/src/zoneinfo/__init__.py
+++ b/src/zoneinfo/__init__.py
@@ -27,4 +27,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(__all__ + ["__version__"])
+    return sorted(list(globals()) + ["TZPATH"])

--- a/src/zoneinfo/_common.py
+++ b/src/zoneinfo/_common.py
@@ -11,6 +11,16 @@ def load_tzdata(key):
     try:
         return importlib.resources.open_binary(package_name, resource_name)
     except (ImportError, FileNotFoundError, UnicodeEncodeError) as e:
+        # There are three types of exception that can be raised that all amount
+        # to "we cannot find this key":
+        #
+        # ImportError: If package_name doesn't exist (e.g. if tzdata is not
+        #   installed, or if there's an error in the folder name like
+        #   Amrica/New_York)
+        # FileNotFoundError: If resource_name doesn't exist in the package
+        #   (e.g. Europe/Krasnoy)
+        # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
+        #   such as keys containing a surrogate character.
         raise ZoneInfoNotFoundError(f"No time zone found with key {key}") from e
 
 

--- a/src/zoneinfo/_common.py
+++ b/src/zoneinfo/_common.py
@@ -10,7 +10,7 @@ def load_tzdata(key):
 
     try:
         return importlib.resources.open_binary(package_name, resource_name)
-    except (ImportError, FileNotFoundError, UnicodeEncodeError) as e:
+    except (ImportError, FileNotFoundError, UnicodeEncodeError):
         # There are three types of exception that can be raised that all amount
         # to "we cannot find this key":
         #
@@ -21,7 +21,7 @@ def load_tzdata(key):
         #   (e.g. Europe/Krasnoy)
         # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
         #   such as keys containing a surrogate character.
-        raise ZoneInfoNotFoundError(f"No time zone found with key {key}") from e
+        raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
 
 
 def load_data(fobj):

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -37,23 +37,23 @@ def reset_tzpath(to=None):
 def _parse_python_tzpath(env_var):
     if not env_var:
         return ()
-    else:
-        raw_tzpath = env_var.split(os.pathsep)
-        new_tzpath = tuple(filter(os.path.isabs, raw_tzpath))
 
-        # If anything has been filtered out, we will warn about it
-        if len(new_tzpath) != len(raw_tzpath):
-            import warnings
+    raw_tzpath = env_var.split(os.pathsep)
+    new_tzpath = tuple(filter(os.path.isabs, raw_tzpath))
 
-            msg = _get_invalid_paths_message(raw_tzpath)
+    # If anything has been filtered out, we will warn about it
+    if len(new_tzpath) != len(raw_tzpath):
+        import warnings
 
-            warnings.warn(
-                "Invalid paths specified in PYTHONTZPATH environment variable."
-                + msg,
-                InvalidTZPathWarning,
-            )
+        msg = _get_invalid_paths_message(raw_tzpath)
 
-        return new_tzpath
+        warnings.warn(
+            "Invalid paths specified in PYTHONTZPATH environment variable."
+            + msg,
+            InvalidTZPathWarning,
+        )
+
+    return new_tzpath
 
 
 def _get_invalid_paths_message(tzpaths):

--- a/src/zoneinfo/_tzpath.py
+++ b/src/zoneinfo/_tzpath.py
@@ -10,7 +10,7 @@ def reset_tzpath(to=None):
         if isinstance(tzpaths, (str, bytes)):
             raise TypeError(
                 f"tzpaths must be a list or tuple, "
-                + f"not {type(tzpaths)}: {tzpaths}"
+                + f"not {type(tzpaths)}: {tzpaths!r}"
             )
         elif not all(map(os.path.isabs, tzpaths)):
             raise ValueError(_get_invalid_paths_message(tzpaths))

--- a/src/zoneinfo/_zoneinfo.py
+++ b/src/zoneinfo/_zoneinfo.py
@@ -657,8 +657,7 @@ def _parse_tz_str(tz_str):
     dst_abbr = m.group("dst")
     dst_offset = None
 
-    if std_abbr:
-        std_abbr = std_abbr.strip("<>")
+    std_abbr = std_abbr.strip("<>")
 
     if dst_abbr:
         dst_abbr = dst_abbr.strip("<>")

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -432,7 +432,7 @@ class CZoneInfoTest(ZoneInfoTest):
         subclass = [False, True]
 
         key = "Europe/London"
-        zi = self.zone_from_key("Europe/London")
+        zi = self.zone_from_key(key)
         for zt in self.load_transition_examples(key):
             if zt.fold and zt.offset_after.utcoffset == ZERO:
                 example = zt.transition_utc.replace(tzinfo=zi)

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1653,6 +1653,30 @@ class CTestModule(TestModule):
     module = c_zoneinfo
 
 
+class ExtensionBuiltTest(unittest.TestCase):
+    """Smoke test to ensure that the C and Python extensions are both tested.
+
+    Because the intention is for the Python and C versions of ZoneInfo to
+    behave identically, these tests necessarily rely on implementation details,
+    so the tests may need to be adjusted if the implementations change. Do not
+    rely on these tests as an indication of stable properties of these classes.
+    """
+
+    def test_cache_location(self):
+        # The pure Python version stores caches on attributes, but the C
+        # extension stores them in C globals (at least for now)
+        self.assertFalse(hasattr(c_zoneinfo.ZoneInfo, "_weak_cache"))
+        self.assertTrue(hasattr(py_zoneinfo.ZoneInfo, "_weak_cache"))
+
+    def test_gc_tracked(self):
+        # The pure Python version is tracked by the GC but (for now) the C
+        # version is not.
+        import gc
+
+        self.assertTrue(gc.is_tracked(py_zoneinfo.ZoneInfo))
+        self.assertFalse(gc.is_tracked(c_zoneinfo.ZoneInfo))
+
+
 @dataclasses.dataclass(frozen=True)
 class ZoneOffset:
     tzname: str


### PR DESCRIPTION
This includes various updates to this module based on feedback and bugs found in merging this functionality into CPython: https://github.com/python/cpython/pull/19909

Including:

- Refleaks
- Cosmetic changes
- Additional tests

The two can't be kept in perfect sync, unfortunately, because the code layout is different (and thus the relative imports and a few other consequences of that), but we can manually backport things until both codebases reach stability.