### PR TITLE
Switch extra dependency to tzdata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 
 [options.extras_require]
 tzdata =
-    tzdata @ git+https://github.com/python/tzdata.git
+    tzdata
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     pytest-randomly
     pytest-subtests
     pytest-xdist
+pip_pre = true
 extras =
     {env:TEST_EXTRAS_TOX:}
 setenv =


### PR DESCRIPTION
We now have release candidates for tzdata available on PyPI, so we can use those as our source for testing. We need to enable `--pre` because old yanked versions exist and `pip==20.1` will choose yanked versions over pre-releases.