### PR TITLE
Add Python 3.7 compatibility

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -57,13 +57,13 @@ jobs:
           docker pull $DOCKER_IMAGE
       - name: Build wheels
         env:
-          PYTHON_TAGS: "cp38-cp38"
+          PYTHON_TAGS: "cp37-cp37m cp38-cp38"
           PRE_CMD:  ${{ matrix.platform == 'manylinux1_i686' && 'linux32' || '' }}
         run: |
           docker run --rm \
             -e PLAT=${{ matrix.platform }} \
-            -e PYTHON_TAGS=$PYTHON_TAGS \
-            -v `pwd`:/io $DOCKER_IMAGE \
+            -e PYTHON_TAGS="$PYTHON_TAGS" \
+            -v `pwd`:/io "$DOCKER_IMAGE" \
             $PRE_CMD \
             /io/scripts/build_manylinux_wheels.sh
       - uses: actions/upload-artifact@v2
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [ '3.8' ]
+        python_version: [ '3.7', '3.8' ]
         arch: [ 'x86', 'x64' ]
         os:
           - 'windows-latest'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.7', '3.8']
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
     env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.7', '3.8']
         os: ["ubuntu-latest"]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `backports.zoneinfo`: Backport of the standard library module `zoneinfo`
 
-This package was originally the reference implementation for [PEP 615](https://www.python.org/dev/peps/pep-0615/), which proposes support for the IANA time zone database in the standard library, and now serves as a backport to Python 3.8.
+This package was originally the reference implementation for [PEP 615](https://www.python.org/dev/peps/pep-0615/), which proposes support for the IANA time zone database in the standard library, and now serves as a backport to Python 3.7+.
 
 This exposes the `backports.zoneinfo` module, which is a backport of the [`zoneinfo`](https://docs.python.org/3.9/library/zoneinfo.html#module-zoneinfo) module. The backport's documentation can be found [on readthedocs](https://zoneinfo.readthedocs.io/en/latest/).
 
@@ -30,7 +30,7 @@ Support for `backports.zoneinfo` in Python 3.9+ is currently minimal, since it i
 
 ## Use
 
-The `backports.zoneinfo` module should be a drop-in replacement for the Python 3.9 standard library module `zoneinfo`. If you do not support anything earlier than Python 3.9, **you do not need this library**; if you are supporting Python 3.8+, you may want to use this idiom to "fall back" to ``backports.zoneinfo``:
+The `backports.zoneinfo` module should be a drop-in replacement for the Python 3.9 standard library module `zoneinfo`. If you do not support anything earlier than Python 3.9, **you do not need this library**; if you are supporting Python 3.7+, you may want to use this idiom to "fall back" to ``backports.zoneinfo``:
 
 ```python
 try:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
 
 This was originally the reference implementation for :pep:`615`, which adds
 support for the IANA time zone database to the Python standard library, but now
-serves as a backport of the module to Python 3.8.
+serves as a backport of the module to Python 3.7+.
 
 The upstream documentation can be found at :mod:`zoneinfo`. A mirror of the
 documentation pinned to the version supported in the backport can be found at

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 project_urls =
     Source = https://github.com/pganssle/zoneinfo
@@ -26,7 +27,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src

--- a/src/backports/zoneinfo/_common.py
+++ b/src/backports/zoneinfo/_common.py
@@ -115,7 +115,6 @@ def load_data(fobj):
         assert c == b"\n", c
 
         tz_bytes = b""
-        # TODO: Walrus operator
         while True:
             c = fobj.read(1)
             if c == b"\n":

--- a/src/backports/zoneinfo/_tzpath.py
+++ b/src/backports/zoneinfo/_tzpath.py
@@ -68,12 +68,27 @@ def _get_invalid_paths_message(tzpaths):
     )
 
 
+if sys.version_info < (3, 8):
+
+    def _isfile(path):
+        # bpo-33721: In Python 3.8 non-UTF8 paths return False rather than
+        # raising an error. See https://bugs.python.org/issue33721
+        try:
+            return os.path.isfile(path)
+        except ValueError:
+            return False
+
+
+else:
+    _isfile = os.path.isfile
+
+
 def find_tzfile(key):
     """Retrieve the path to a TZif file from a key."""
     _validate_tzfile_path(key)
     for search_path in TZPATH:
         filepath = os.path.join(search_path, key)
-        if os.path.isfile(filepath):
+        if _isfile(filepath):
             return filepath
 
     return None

--- a/src/backports/zoneinfo/_zoneinfo.py
+++ b/src/backports/zoneinfo/_zoneinfo.py
@@ -78,7 +78,7 @@ class ZoneInfo(tzinfo):
         return obj
 
     @classmethod
-    def from_file(cls, fobj, /, key=None):
+    def from_file(cls, fobj, key=None):
         obj = super().__new__(cls)
         obj._key = key
         obj._file_path = None
@@ -216,7 +216,7 @@ class ZoneInfo(tzinfo):
         )
 
     @classmethod
-    def _unpickle(cls, key, from_cache, /):
+    def _unpickle(cls, key, from_cache):
         if from_cache:
             return cls(key)
         else:
@@ -662,7 +662,8 @@ def _parse_tz_str(tz_str):
     if dst_abbr:
         dst_abbr = dst_abbr.strip("<>")
 
-    if std_offset := m.group("stdoff"):
+    std_offset = m.group("stdoff")
+    if std_offset:
         try:
             std_offset = _parse_tz_delta(std_offset)
         except ValueError as e:
@@ -671,7 +672,8 @@ def _parse_tz_str(tz_str):
         std_offset = 0
 
     if dst_abbr is not None:
-        if dst_offset := m.group("dstoff"):
+        dst_offset = m.group("dstoff")
+        if dst_offset:
             try:
                 dst_offset = _parse_tz_delta(dst_offset)
             except ValueError as e:

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ description = Run the tests
 deps =
     coverage[toml]
     hypothesis>=5.7.0
+    importlib_metadata; python_version<"3.8"
     pytest
     pytest-cov
     pytest-randomly

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,6 @@ commands =
           -o {toxworkdir}/.coverage/.gcov_coverage.{envname}.xml
 
 [testenv:coverage-report]
-basepython = python3.8
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends = py38


### PR DESCRIPTION
Just a few minor tweaks was all that was necessary for this. The positional-only arguments are not enforced in the pure Python version because it's too much of a hassle :cry: 