### PR TITLE
Add Python 3.6 compatibility

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -57,7 +57,7 @@ jobs:
           docker pull $DOCKER_IMAGE
       - name: Build wheels
         env:
-          PYTHON_TAGS: "cp37-cp37m cp38-cp38"
+          PYTHON_TAGS: "cp36-cp36m cp37-cp37m cp38-cp38"
           PRE_CMD:  ${{ matrix.platform == 'manylinux1_i686' && 'linux32' || '' }}
         run: |
           docker run --rm \
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [ '3.7', '3.8' ]
+        python_version: [ '3.6', '3.7', '3.8' ]
         arch: [ 'x86', 'x64' ]
         os:
           - 'windows-latest'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
     env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
         os: ["ubuntu-latest"]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `backports.zoneinfo`: Backport of the standard library module `zoneinfo`
 
-This package was originally the reference implementation for [PEP 615](https://www.python.org/dev/peps/pep-0615/), which proposes support for the IANA time zone database in the standard library, and now serves as a backport to Python 3.7+.
+This package was originally the reference implementation for [PEP 615](https://www.python.org/dev/peps/pep-0615/), which proposes support for the IANA time zone database in the standard library, and now serves as a backport to Python 3.6+.
 
 This exposes the `backports.zoneinfo` module, which is a backport of the [`zoneinfo`](https://docs.python.org/3.9/library/zoneinfo.html#module-zoneinfo) module. The backport's documentation can be found [on readthedocs](https://zoneinfo.readthedocs.io/en/latest/).
 
@@ -30,7 +30,7 @@ Support for `backports.zoneinfo` in Python 3.9+ is currently minimal, since it i
 
 ## Use
 
-The `backports.zoneinfo` module should be a drop-in replacement for the Python 3.9 standard library module `zoneinfo`. If you do not support anything earlier than Python 3.9, **you do not need this library**; if you are supporting Python 3.7+, you may want to use this idiom to "fall back" to ``backports.zoneinfo``:
+The `backports.zoneinfo` module should be a drop-in replacement for the Python 3.9 standard library module `zoneinfo`. If you do not support anything earlier than Python 3.9, **you do not need this library**; if you are supporting Python 3.6+, you may want to use this idiom to "fall back" to ``backports.zoneinfo``:
 
 ```python
 try:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
 
 This was originally the reference implementation for :pep:`615`, which adds
 support for the IANA time zone database to the Python standard library, but now
-serves as a backport of the module to Python 3.7+.
+serves as a backport of the module to Python 3.6+.
 
 The upstream documentation can be found at :mod:`zoneinfo`. A mirror of the
 documentation pinned to the version supported in the backport can be found at

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 project_urls =
@@ -27,7 +28,9 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.7
+install_requires =
+    importlib_resources;python_version<"3.7"
+python_requires = >=3.6
 include_package_data = True
 package_dir =
     =src

--- a/src/backports/zoneinfo/__init__.py
+++ b/src/backports/zoneinfo/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "ZoneInfoNotFoundError",
     "InvalidTZPathWarning",
 ]
+import sys
 
 from . import _tzpath
 from ._common import ZoneInfoNotFoundError
@@ -20,12 +21,28 @@ reset_tzpath = _tzpath.reset_tzpath
 available_timezones = _tzpath.available_timezones
 InvalidTZPathWarning = _tzpath.InvalidTZPathWarning
 
+if sys.version_info < (3, 7):
+    # Module-level __getattr__ was added in Python 3.7, so instead of lazily
+    # populating TZPATH on every access, we will register a callback with
+    # reset_tzpath to update the top-level tuple.
+    TZPATH = _tzpath.TZPATH
 
-def __getattr__(name):
-    if name == "TZPATH":
-        return _tzpath.TZPATH
-    else:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    def _tzpath_callback(new_tzpath):
+        global TZPATH
+        TZPATH = new_tzpath
+
+    _tzpath.TZPATH_CALLBACKS.append(_tzpath_callback)
+    del _tzpath_callback
+
+else:
+
+    def __getattr__(name):
+        if name == "TZPATH":
+            return _tzpath.TZPATH
+        else:
+            raise AttributeError(
+                f"module {__name__!r} has no attribute {name!r}"
+            )
 
 
 def __dir__():

--- a/src/backports/zoneinfo/_common.py
+++ b/src/backports/zoneinfo/_common.py
@@ -2,14 +2,17 @@ import struct
 
 
 def load_tzdata(key):
-    import importlib.resources
+    try:
+        import importlib.resources as importlib_resources
+    except ImportError:
+        import importlib_resources
 
     components = key.split("/")
     package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
     resource_name = components[-1]
 
     try:
-        return importlib.resources.open_binary(package_name, resource_name)
+        return importlib_resources.open_binary(package_name, resource_name)
     except (ImportError, FileNotFoundError, UnicodeEncodeError):
         # There are three types of exception that can be raised that all amount
         # to "we cannot find this key":

--- a/src/backports/zoneinfo/_tzpath.py
+++ b/src/backports/zoneinfo/_tzpath.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+PY36 = sys.version_info < (3, 7)
+
 
 def reset_tzpath(to=None):
     global TZPATH
@@ -32,6 +34,10 @@ def reset_tzpath(to=None):
             base_tzpath = ()
 
     TZPATH = tuple(base_tzpath)
+
+    if TZPATH_CALLBACKS:
+        for callback in TZPATH_CALLBACKS:
+            callback(TZPATH)
 
 
 def _parse_python_tzpath(env_var):
@@ -132,7 +138,10 @@ def available_timezones():
         determine if a given file on the time zone search path is to open it
         and check for the "magic string" at the beginning.
     """
-    from importlib import resources
+    try:
+        from importlib import resources
+    except ImportError:
+        import importlib_resources as resources
 
     valid_zones = set()
 
@@ -193,4 +202,5 @@ class InvalidTZPathWarning(RuntimeWarning):
 
 
 TZPATH = ()
+TZPATH_CALLBACKS = []
 reset_tzpath()

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import contextlib
 import dataclasses

--- a/tests/test_zoneinfo_property.py
+++ b/tests/test_zoneinfo_property.py
@@ -3,7 +3,6 @@ import datetime
 import os
 import pickle
 import unittest
-from importlib import resources
 
 import hypothesis
 import pytest
@@ -12,6 +11,12 @@ from backports import zoneinfo
 
 from . import _support as test_support
 from ._support import ZoneInfoTestBase
+
+try:
+    from importlib import resources
+except ImportError:
+    import importlib_resources as resources
+
 
 py_zoneinfo, c_zoneinfo = test_support.get_modules()
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ requires = tox-pip-version
 description = Run the tests
 deps =
     coverage[toml]
+    dataclasses; python_version<"3.7"
     hypothesis>=5.7.0
     importlib_metadata; python_version<"3.8"
     pytest
@@ -32,7 +33,9 @@ description = Run the tests and collect C coverage stats
 pip_version = pip==20.1
 deps =
     gcovr
+    dataclasses; python_version<"3.7"
     hypothesis>=5.7.0
+    importlib_metadata; python_version<"3.8"
     pytest
     pytest-subtests
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 minversion = 3.3.0
 isolated_build = True
 skip_missing_interpreters = true
-requires = tox-pip-version
 
 [testenv]
 description = Run the tests
@@ -30,7 +29,6 @@ commands =
 # it's not necessarily very cross-platform, I've split it out for now.
 [testenv:gcov]
 description = Run the tests and collect C coverage stats
-pip_version = pip==20.1
 deps =
     gcovr
     dataclasses; python_version<"3.7"


### PR DESCRIPTION
I wasn't sure I was going to do this, but it turned out to be pretty easy, so this module is now also compatible with Python 3.6.