### PR TITLE
Add pylint and delint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@ repos:
         additional_dependencies: [toml]
         language_version: python3.8
 
+  - repo: https://github.com/pycqa/pylint
+    rev: pylint-2.5.2
+    hooks:
+    -   id: pylint
+
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,17 @@ known_third_party=[
 multi_line_output=3
 not_skip="__init__.py"
 use_parentheses=true
+
+[tool.pylint.'MESSAGES CONTROL']
+disable="all"
+enable="""
+    unused-import,
+    unused-variable,
+    unpacking-non-sequence,
+    invalid-all-object,
+    used-before-assignment,
+    no-else-raise,
+    bad-format-character,
+    bad-format-string,
+    bare-except,
+"""

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,8 +1,7 @@
-import functools
 import statistics
 import sys
 import timeit
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import click
 import pint

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -205,7 +205,7 @@ def run_benchmark(desc, func, k=5, N=None):
 
     # Run for 0.2 seconds
     if N is None:
-        N, time_taken = timer.autorange()
+        N, time_taken = timer.autorange()  # pylint: disable=unused-variable
 
     results = timer.repeat(repeat=k, number=N)
     results = [r / N for r in results]

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -184,7 +184,8 @@ def cli(benchmark, zone, compare, c_ext, py):
     # Determine which benchmarks to run
     if not benchmark:
         raise InvalidInput("No benchmarks specified")
-    elif len(benchmark) == 1 and benchmark[0] == "all":
+
+    if len(benchmark) == 1 and benchmark[0] == "all":
         benchmarks = sorted(BENCHMARKS.keys())
     else:
         if "all" in benchmark:

--- a/src/backports/zoneinfo/_common.py
+++ b/src/backports/zoneinfo/_common.py
@@ -83,7 +83,6 @@ def load_data(fobj):
     # not by position in the array but by position in the unsplit
     # abbreviation string. I suppose this makes more sense in C, which uses
     # null to terminate the strings, but it's inconvenient here...
-    char_total = 0
     abbr_vals = {}
     abbr_chars = fobj.read(charcnt)
 

--- a/src/backports/zoneinfo/_tzpath.py
+++ b/src/backports/zoneinfo/_tzpath.py
@@ -14,7 +14,8 @@ def reset_tzpath(to=None):
                 f"tzpaths must be a list or tuple, "
                 + f"not {type(tzpaths)}: {tzpaths!r}"
             )
-        elif not all(map(os.path.isabs, tzpaths)):
+
+        if not all(map(os.path.isabs, tzpaths)):
             raise ValueError(_get_invalid_paths_message(tzpaths))
         base_tzpath = tzpaths
     else:

--- a/src/backports/zoneinfo/_zoneinfo.py
+++ b/src/backports/zoneinfo/_zoneinfo.py
@@ -2,12 +2,9 @@ import bisect
 import calendar
 import collections
 import functools
-import os
 import re
-import struct
-import sys
 import weakref
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import datetime, timedelta, tzinfo
 
 from . import _common, _tzpath
 

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -324,7 +324,7 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                     # Assign a random variable here to disable the peephole
                     # optimizer so that coverage can see this line.
                     # See bpo-2506 for more information.
-                    no_peephole_opt = None
+                    no_peephole_opt = None  # pylint: disable=unused-variable
                     continue
 
                 # Cases are of the form key, dt, fold, offset
@@ -367,7 +367,6 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                     self.assertEqual(dt.dst(), offset.dst, dt)
 
     def test_folds_from_utc(self):
-        tests = []
         for key in self.zones():
             zi = self.zone_from_key(key)
             with self.subTest(key=key):
@@ -929,7 +928,7 @@ class TZStrTest(ZoneInfoTestBase):
         # the Version 2+ file. In this case, we have no transitions, just
         # the tzstr in the footer, so up to the footer, the files are
         # identical and we can just write the same file twice in a row.
-        for i in range(2):
+        for _ in range(2):
             out += b"TZif"  # Magic value
             out += b"3"  # Version
             out += b" " * 15  # Reserved
@@ -954,7 +953,6 @@ class TZStrTest(ZoneInfoTestBase):
         return self.klass.from_file(zonefile, key=tzstr)
 
     def test_tzstr_localized(self):
-        i = 0
         for tzstr, cases in self.test_cases.items():
             with self.subTest(tzstr=tzstr):
                 zi = self.zone_from_tzstr(tzstr)

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -15,12 +15,7 @@ import unittest
 from datetime import date, datetime, time, timedelta, timezone
 
 from . import _support as test_support
-from ._support import (
-    OS_ENV_LOCK,
-    TZPATH_LOCK,
-    TZPATH_TEST_LOCK,
-    ZoneInfoTestBase,
-)
+from ._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
 
 try:
     from functools import cached_property

--- a/tests/test_zoneinfo_property.py
+++ b/tests/test_zoneinfo_property.py
@@ -256,7 +256,8 @@ class PythonCConsistencyTest(unittest.TestCase):
 
         if (py_overflow_exc is not None) != (c_overflow_exc is not None):
             raise py_overflow_exc or c_overflow_exc  # pragma: nocover
-        elif py_overflow_exc is not None:
+
+        if py_overflow_exc is not None:
             return  # Consistently raises the same exception
 
         # PEP 495 says that an inter-zone comparison between ambiguous
@@ -296,7 +297,8 @@ class PythonCConsistencyTest(unittest.TestCase):
 
         if (py_overflow_exc is not None) != (c_overflow_exc is not None):
             raise py_overflow_exc or c_overflow_exc  # pragma: nocover
-        elif py_overflow_exc is not None:
+
+        if py_overflow_exc is not None:
             return  # Consistently raises the same exception
 
         self.assertEqual(py_utc, c_utc)

--- a/tox.ini
+++ b/tox.ini
@@ -90,9 +90,11 @@ skip_install = True
 deps =
     black
     isort
+    pylint
 commands =
     black --check .
     isort --check-only --recursive scripts src tests docs
+    pylint docs scripts src tests
 
 [testenv:benchmark]
 description = Run benchmarks


### PR DESCRIPTION
`pylint` is useful for some linting rules [but it is way too noisy](https://pythonspeed.com/articles/pylint/), so I've gone with a pretty tightly-scoped whitelist of rules to enable.