### PR TITLE
Compiler warnings

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -103,6 +103,8 @@ jobs:
       - name: Create tox environment
         run: tox -e build --notest
       - name: Build wheel
+        env:
+          CL: ${{ matrix.os == 'windows-latest' && '/WX /wd4068' || '' }}
         run: |
           tox -e build -- -b
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -78,6 +78,7 @@ jobs:
             CFLAGS+=" -Wno-unused-result"
             CFLAGS+=" -Wno-unused-parameter"
             CFLAGS+=" -Wno-missing-field-initializers"
+            CFLAGS+=" -Wno-unknown-pragmas"
             export CFLAGS="${CFLAGS}"
             TOXENV="build,build-check"
           fi

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -43,8 +43,8 @@ typedef struct {
     PyObject *key;
     PyObject *file_repr;
     PyObject *weakreflist;
-    unsigned int num_transitions;
-    unsigned int num_ttinfos;
+    size_t num_transitions;
+    size_t num_ttinfos;
     int64_t *trans_list_utc;
     int64_t *trans_list_wall[2];
     _ttinfo **trans_ttinfos;  // References to the ttinfo for each transition
@@ -909,12 +909,12 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
 
     // Load the relevant sizes
     Py_ssize_t num_transitions = PyTuple_Size(trans_utc);
-    if (num_transitions == -1) {
+    if (num_transitions < 0) {
         goto error;
     }
 
     Py_ssize_t num_ttinfos = PyTuple_Size(utcoff_list);
-    if (num_ttinfos == -1) {
+    if (num_ttinfos < 0) {
         goto error;
     }
 
@@ -926,7 +926,7 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
         PyMem_Malloc(self->num_transitions * sizeof(int64_t));
     trans_idx = PyMem_Malloc(self->num_transitions * sizeof(Py_ssize_t));
 
-    for (Py_ssize_t i = 0; i < self->num_transitions; ++i) {
+    for (size_t i = 0; i < self->num_transitions; ++i) {
         PyObject *num = PyTuple_GetItem(trans_utc, i);
         if (num == NULL) {
             goto error;
@@ -964,7 +964,7 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     if (utcoff == NULL || isdst == NULL) {
         goto error;
     }
-    for (Py_ssize_t i = 0; i < self->num_ttinfos; ++i) {
+    for (size_t i = 0; i < self->num_ttinfos; ++i) {
         PyObject *num = PyTuple_GetItem(utcoff_list, i);
         if (num == NULL) {
             goto error;

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -124,14 +124,14 @@ ts_to_local(size_t *trans_idx, int64_t *trans_utc, long *utcoff,
 static int
 parse_tz_str(PyObject *tz_str_obj, _tzrule *out);
 
-static ssize_t
+static Py_ssize_t
 parse_abbr(const char *const p, PyObject **abbr);
-static ssize_t
+static Py_ssize_t
 parse_tz_delta(const char *const p, long *total_seconds);
-static ssize_t
+static Py_ssize_t
 parse_transition_time(const char *const p, int8_t *hour, int8_t *minute,
                       int8_t *second);
-static ssize_t
+static Py_ssize_t
 parse_transition_rule(const char *const p, TransitionRuleType **out);
 
 static _ttinfo *
@@ -1484,7 +1484,7 @@ parse_tz_str(PyObject *tz_str_obj, _tzrule *out)
     char *p = tz_str;
 
     // Read the `std` abbreviation, which must be at least 3 characters long.
-    ssize_t num_chars = parse_abbr(p, &std_abbr);
+    Py_ssize_t num_chars = parse_abbr(p, &std_abbr);
     if (num_chars < 1) {
         PyErr_Format(PyExc_ValueError, "Invalid STD format in %R", tz_str_obj);
         goto error;
@@ -1581,7 +1581,7 @@ error:
     return -1;
 }
 
-static ssize_t
+static Py_ssize_t
 parse_uint(const char *const p)
 {
     if (!isdigit(*p)) {
@@ -1592,7 +1592,7 @@ parse_uint(const char *const p)
 }
 
 /* Parse the STD and DST abbreviations from a TZ string. */
-static ssize_t
+static Py_ssize_t
 parse_abbr(const char *const p, PyObject **abbr)
 {
     const char *ptr = p;
@@ -1645,7 +1645,7 @@ parse_abbr(const char *const p, PyObject **abbr)
 }
 
 /* Parse a UTC offset from a TZ str. */
-static ssize_t
+static Py_ssize_t
 parse_tz_delta(const char *const p, long *total_seconds)
 {
     // From the POSIX spec:
@@ -1728,7 +1728,7 @@ complete:
 }
 
 /* Parse the date portion of a transition rule. */
-static ssize_t
+static Py_ssize_t
 parse_transition_rule(const char *const p, TransitionRuleType **out)
 {
     // The full transition rule indicates when to change back and forth between
@@ -1755,7 +1755,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
     if (*ptr == 'M') {
         uint8_t month, week, day;
         ptr++;
-        ssize_t tmp = parse_uint(ptr);
+        Py_ssize_t tmp = parse_uint(ptr);
         if (tmp < 0) {
             return -1;
         }
@@ -1790,7 +1790,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
 
         if (*ptr == '/') {
             ptr++;
-            ssize_t num_chars =
+            Py_ssize_t num_chars =
                 parse_transition_time(ptr, &hour, &minute, &second);
             if (num_chars < 0) {
                 return -1;
@@ -1832,7 +1832,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
 
         if (*ptr == '/') {
             ptr++;
-            ssize_t num_chars =
+            Py_ssize_t num_chars =
                 parse_transition_time(ptr, &hour, &minute, &second);
             if (num_chars < 0) {
                 return -1;
@@ -1856,7 +1856,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
 }
 
 /* Parse the time portion of a transition rule (e.g. following an /) */
-static ssize_t
+static Py_ssize_t
 parse_transition_time(const char *const p, int8_t *hour, int8_t *minute,
                       int8_t *second)
 {

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -1780,7 +1780,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
             ptr++;
 
             tmp = parse_uint(ptr);
-            if (tmp < 0) {
+            if (tmp < 0 || tmp >= 256) {
                 return -1;
             }
             ptr++;

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -1785,7 +1785,13 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
             }
             ptr++;
 
+            // The Windows compiler complains about a possible reduction in
+            // precision when casting from Py_ssize_t to uint8_t, but the check
+            // above ensures that the result is within the allowed range.
+#pragma warning(push)
+#pragma warning(disable : 4244)
             *(values[i]) = tmp;
+#pragma warning(pop)
         }
 
         if (*ptr == '/') {

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -1475,7 +1475,9 @@ parse_tz_str(PyObject *tz_str_obj, _tzrule *out)
     PyObject *dst_abbr = NULL;
     TransitionRuleType *start = NULL;
     TransitionRuleType *end = NULL;
-    long std_offset, dst_offset;
+    // Initialize offsets to invalid value (> 24 hours)
+    long std_offset = 1 << 20;
+    long dst_offset = 1 << 20;
 
     char *tz_str = PyBytes_AsString(tz_str_obj);
     if (tz_str == NULL) {
@@ -1921,7 +1923,7 @@ build_tzrule(PyObject *std_abbr, PyObject *dst_abbr, long std_offset,
              long dst_offset, TransitionRuleType *start,
              TransitionRuleType *end, _tzrule *out)
 {
-    _tzrule rv = {0};
+    _tzrule rv = {{0}};
 
     rv.start = start;
     rv.end = end;


### PR DESCRIPTION
This now enforces that the Windows compiler treats all warnings as errors, except for the "unknown pragma" warning, which is incompatible with the GCC error-disabling pragmas.

I've also disabled one warning about possible precision loss and ensured that the runtime logic prevents precision loss in any of these situations.