### PR TITLE
Add pypy support

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8', 'pypy3']
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
     env:
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip tox
     - name: Run tests
       run: |
-        tox
+        python -m tox
     - name: Report coverage
       run: |
         tox -e coverage-report,codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `backports.zoneinfo`: Backport of the standard library module `zoneinfo`
 
-This package was originally the reference implementation for [PEP 615](https://www.python.org/dev/peps/pep-0615/), which proposes support for the IANA time zone database in the standard library, and now serves as a backport to Python 3.6+.
+This package was originally the reference implementation for [PEP 615](https://www.python.org/dev/peps/pep-0615/), which proposes support for the IANA time zone database in the standard library, and now serves as a backport to Python 3.6+ (including PyPy).
 
 This exposes the `backports.zoneinfo` module, which is a backport of the [`zoneinfo`](https://docs.python.org/3.9/library/zoneinfo.html#module-zoneinfo) module. The backport's documentation can be found [on readthedocs](https://zoneinfo.readthedocs.io/en/latest/).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
 
 This was originally the reference implementation for :pep:`615`, which adds
 support for the IANA time zone database to the Python standard library, but now
-serves as a backport of the module to Python 3.6+.
+serves as a backport of the module to Python 3.6+ (including PyPy).
 
 The upstream documentation can be found at :mod:`zoneinfo`. A mirror of the
 documentation pinned to the version supported in the backport can be found at

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 import os
+import platform
 
 import setuptools
 from setuptools import Extension
 
-c_extension = Extension(
-    "backports.zoneinfo._czoneinfo", sources=["lib/zoneinfo_module.c"],
-)
+if platform.python_implementation() != "PyPy":
+    c_extension = Extension(
+        "backports.zoneinfo._czoneinfo", sources=["lib/zoneinfo_module.c"],
+    )
 
-setuptools.setup(ext_modules=[c_extension])
+    setuptools.setup(ext_modules=[c_extension])
+else:
+    setuptools.setup()
+
 
 if "GCNO_TARGET_DIR" in os.environ:
     import glob

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -15,7 +15,7 @@ import unittest
 from datetime import date, datetime, time, timedelta, timezone
 
 from . import _support as test_support
-from ._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
+from ._support import IS_PYPY, OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
 
 try:
     from functools import cached_property
@@ -1771,6 +1771,7 @@ class CTestModule(TestModule):
     module = c_zoneinfo
 
 
+@unittest.skipIf(IS_PYPY, "C Extension not built on PyPy")
 class ExtensionBuiltTest(unittest.TestCase):
     """Smoke test to ensure that the C and Python extensions are both tested.
 


### PR DESCRIPTION
For now this only works with source distributions — I'd like to ship a PyPy wheel, but I can't figure out how to tag it so that it will *only* get picked up on PyPy.

I have an alternate version of this that actually allows the C extension to compile on PyPy, but on PyPy the C extension is way slower than the Python implementation (which for a lot of these benchmarks is actually faster than the C extension on CPython):

```
Running constructor in zone America/New_York
c_zoneinfo: mean: 490.79 ns ± 16.89 ns; min: 468.35 ns (k=5, N=1000000)
py_zoneinfo: mean: 49.54 ns ± 2.07 ns; min: 47.39 ns (k=5, N=10000000)
pytz: mean: 1.71 µs ± 70.73 ns; min: 1.66 µs (k=5, N=1000000)

Running constructor_strong_cache_miss in zone America/New_York
c_zoneinfo: mean: 28.57 µs ± 3.71 µs; min: 24.29 µs (k=5, N=10000)
py_zoneinfo: mean: 957.39 ns ± 40.07 ns; min: 913.89 ns (k=5, N=1000000)

Running from_utc in zone America/New_York
c_zoneinfo: mean: 4.93 µs ± 143.32 ns; min: 4.73 µs (k=5, N=100000)
py_zoneinfo: mean: 495.16 ns ± 41.14 ns; min: 452.01 ns (k=5, N=1000000)
pytz: mean: 627.67 ns ± 12.06 ns; min: 614.56 ns (k=5, N=1000000)

Running no_cache_constructor in zone America/New_York
c_zoneinfo: mean: 264.79 µs ± 36.98 µs; min: 229.38 µs (k=5, N=1000)
py_zoneinfo: mean: 106.52 µs ± 63.78 µs; min: 51.60 µs (k=5, N=1000)

Running to_utc in zone America/New_York
c_zoneinfo: mean: 3.44 µs ± 60.76 ns; min: 3.37 µs (k=5, N=100000)
py_zoneinfo: mean: 472.54 ns ± 39.36 ns; min: 432.28 ns (k=5, N=1000000)
pytz: mean: 332.76 ns ± 3.78 ns; min: 328.54 ns (k=5, N=1000000)

Running utcoffset in zone America/New_York
c_zoneinfo: mean: 3.45 µs ± 52.71 ns; min: 3.40 µs (k=5, N=100000)
py_zoneinfo: mean: 336.64 ns ± 11.60 ns; min: 325.69 ns (k=5, N=1000000)
pytz: mean: 213.31 ns ± 5.82 ns; min: 204.82 ns (k=5, N=10000000)
```

In the future, we'll probably want to be smarter about dropping the C extension tests entirely on PyPy, since this basically just runs all the same tests twice right now.