### PR TITLE
Refactor error disabling

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -104,7 +104,7 @@ jobs:
         run: tox -e build --notest
       - name: Build wheel
         env:
-          CL: ${{ matrix.os == 'windows-latest' && '/WX /wd4068' || '' }}
+          CL: ${{ matrix.os == 'windows-latest' && '/WX' || '' }}
         run: |
           tox -e build -- -b
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -78,7 +78,6 @@ jobs:
             CFLAGS+=" -Wno-unused-result"
             CFLAGS+=" -Wno-unused-parameter"
             CFLAGS+=" -Wno-missing-field-initializers"
-            CFLAGS+=" -Wno-unknown-pragmas"
             export CFLAGS="${CFLAGS}"
             TOXENV="build,build-check"
           fi

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run action
         run: |
           if [[ $TOXENV == "build" ]]; then
-            CFLAGS="-std=c99"
+            CFLAGS=""
             CFLAGS+=" -Wall"
             CFLAGS+=" -Werror"
             CFLAGS+=" -Wextra"

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -14,6 +14,17 @@
 #endif
 #endif
 
+#ifdef __GNUC__
+#define DO_PRAGMA(x) _Pragma(#x)
+#define COMPILER_WARNING_DISABLE_GCC_PUSH(err) \
+    DO_PRAGMA(GCC diagnostic push)             \
+    DO_PRAGMA(GCC diagnostic ignored err)
+#define COMPILER_WARNING_DISABLE_GCC_POP _Pragma("GCC diagnostic pop")
+#else
+#define COMPILER_WARNING_DISABLE_GCC_PUSH(err)
+#define COMPILER_WARNING_DISABLE_GCC_POP
+#endif
+
 // Imports
 static PyObject *io_open = NULL;
 static PyObject *_tzpath_find_tzfile = NULL;
@@ -1239,10 +1250,10 @@ calendarrule_new(uint8_t month, uint8_t week, uint8_t day, int8_t hour,
     // it may create a bug. Considering that the compiler should be able to
     // optimize out the first comparison if day is an unsigned integer anyway,
     // we will leave this comparison in place and disable the compiler warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtype-limits"
+
+    COMPILER_WARNING_DISABLE_GCC_PUSH("-Wtype-limits")
     if (day < 0 || day > 6) {
-#pragma GCC diagnostic pop
+        COMPILER_WARNING_DISABLE_GCC_POP
         PyErr_Format(PyExc_ValueError, "Day must be in [0, 6]");
         return -1;
     }

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,26 @@
 import os
 import platform
+import sys
 
 import setuptools
 from setuptools import Extension
 
 if platform.python_implementation() != "PyPy":
+    # We need to pass the -std=c99 to gcc and/or clang, but we shouldn't pass
+    # it to MSVC. There doesn't seem to be a simple way of setting
+    # compiler-specific compile arguments, but for practical purposes
+    # conditionally adding this argument on non-Windows platforms should be
+    # enough. If an edge case is found that prevents compilation on some
+    # systems, the end user should be able to set CFLAGS="-std=c99".
+    if not sys.platform.startswith("win"):
+        extra_compile_args = ["-std=c99"]
+    else:
+        extra_compile_args = []
+
     c_extension = Extension(
-        "backports.zoneinfo._czoneinfo", sources=["lib/zoneinfo_module.c"],
+        "backports.zoneinfo._czoneinfo",
+        sources=["lib/zoneinfo_module.c"],
+        extra_compile_args=extra_compile_args,
     )
 
     setuptools.setup(ext_modules=[c_extension])


### PR DESCRIPTION
This uses a macro to use the "disable this warning on GCC" pragmas only on GCC, to avoid "unknown pragma" warnings on other compilers.