### PR TITLE
Use static type assertion in place of warning suppression

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -63,11 +63,36 @@ jobs:
         run: |
           tox -e gcov,codecov
 
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        cc: ["gcc", "clang"]
+    env:
+      CC: ${{ matrix.cc }}
+      CFLAGS: >
+        -Wall
+        -Werror
+        -Wextra
+        -Wno-unused-result
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+    steps:
+      - uses: actions/checkout@v2
+      - name: ${{ matrix.toxenv }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: python -m pip install --upgrade pip tox
+      - name: Build
+        run: tox -e build,build-check
+
   other:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        toxenv: ["lint", "build", "docs", "mypy"]
+        toxenv: ["lint", "docs", "mypy"]
     env:
       TOXENV: ${{ matrix.toxenv }}
 


### PR DESCRIPTION
It is annoyingly difficult to suppress these unnecessary warnings, but adding a static assertion about the type of the variable `day` essentially accomplishes the same goal (even if it does so only on one compiler), so this should solve the problem.