### PR TITLE
Fix subclassing in C implementation

### DIFF
--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -2581,7 +2581,7 @@ static PyMethodDef zoneinfo_methods[] = {
     {"_unpickle", (PyCFunction)zoneinfo__unpickle, METH_VARARGS | METH_CLASS,
      PyDoc_STR("Private method used in unpickling.")},
     {"__init_subclass__", (PyCFunction)(void (*)(void))zoneinfo_init_subclass,
-     METH_VARARGS | METH_KEYWORDS,
+     METH_VARARGS | METH_KEYWORDS | METH_CLASS,
      PyDoc_STR("Function to initialize subclasses.")},
     {NULL} /* Sentinel */
 };

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -469,7 +469,7 @@ class CZoneInfoDatetimeSubclassTest(DatetimeSubclassMixin, CZoneInfoTest):
     pass
 
 
-class ZoneInfoTestSubclass(ZoneInfoTest):
+class ZoneInfoSubclassTest(ZoneInfoTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -490,7 +490,7 @@ class ZoneInfoTestSubclass(ZoneInfoTest):
         self.assertIsInstance(sub_obj, self.klass)
 
 
-class CZoneInfoTestSubclass(ZoneInfoTest):
+class CZoneInfoSubclassTest(ZoneInfoSubclassTest):
     module = c_zoneinfo
 
 


### PR DESCRIPTION
`__init_subclass__` was not a classmethod, which means that subclassing `ZoneInfo` was impossible. This was missed because the C module "subclass" test case was not actually testing the subclass, and was actually just running the exact same tests as CZoneInfoTest.

Fixes #82 

CC @sdispater