### PR TITLE
Upgrade isort to version >=5.0.0

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -48,8 +48,6 @@ jobs:
     name: Build a ${{ matrix.platform }} for ${{ matrix.python_tag }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: sudo apt-get install docker
       - name: Install docker image
         run: |
           DOCKER_IMAGE="quay.io/pypa/${{ matrix.platform }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         language_version: python3.8
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.4.2
     hooks:
       - id: isort
         additional_dependencies: [toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ known_third_party=[
     "requests",
 ]
 multi_line_output=3
-not_skip="__init__.py"
 use_parentheses=true
 
 [tool.pylint.'MESSAGES CONTROL']

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -50,8 +50,8 @@ def get_modules():
         import_fresh_module("backports.zoneinfo") for _ in range(2)
     )
 
-    from backports.zoneinfo import _zoneinfo as py_zoneinfo
     from backports.zoneinfo import _czoneinfo as c_zoneinfo
+    from backports.zoneinfo import _zoneinfo as py_zoneinfo
 
     py_module.ZoneInfo = py_zoneinfo.ZoneInfo
     c_module.ZoneInfo = c_zoneinfo.ZoneInfo

--- a/tox.ini
+++ b/tox.ini
@@ -78,10 +78,10 @@ whitelist_externals =
     bash
 deps =
     black
-    isort
+    isort>=5.0.0
 commands =
     black .
-    isort -rc scripts src tests docs
+    isort scripts src tests docs
     bash -c 'clang-format --verbose -i lib/*.c'
 
 [testenv:lint]
@@ -89,11 +89,11 @@ description = Run linting checks
 skip_install = True
 deps =
     black
-    isort
+    isort>=5.0.0
     pylint
 commands =
     black --check .
-    isort --check-only --recursive scripts src tests docs
+    isort --check-only scripts src tests docs
     pylint docs scripts src tests
 
 [testenv:benchmark]


### PR DESCRIPTION
`isort` now acts recursively by default, and skips `__init__.py` by default. It apparently also has changed the sort order slightly, so this should now be in compliance.

This also fixes an issue with `docker`.