### PR TITLE
Fix refleaks in ZoneInfo code

### DIFF
--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -2549,6 +2549,7 @@ zoneinfo_init_subclass(PyTypeObject *cls, PyObject *args, PyObject **kwargs)
     }
 
     PyObject_SetAttrString((PyObject *)cls, "_weak_cache", weak_cache);
+    Py_DECREF(weak_cache);
     Py_RETURN_NONE;
 }
 

--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -426,7 +426,6 @@ zoneinfo_clear_cache(PyObject *cls, PyObject *args, PyObject *kwargs)
         }
 
         clear_strong_cache(type);
-        ZONEINFO_STRONG_CACHE = NULL;
     }
     else {
         PyObject *item = NULL;
@@ -2496,6 +2495,7 @@ clear_strong_cache(const PyTypeObject *const type)
     }
 
     strong_cache_free(ZONEINFO_STRONG_CACHE);
+    ZONEINFO_STRONG_CACHE = NULL;
 }
 
 static PyObject *
@@ -2643,8 +2643,7 @@ module_free()
         Py_CLEAR(ZONEINFO_WEAK_CACHE);
     }
 
-    strong_cache_free(ZONEINFO_STRONG_CACHE);
-    ZONEINFO_STRONG_CACHE = NULL;
+    clear_strong_cache(&PyZoneInfo_ZoneInfoType);
 }
 
 static int


### PR DESCRIPTION
Reported in CPython [bpo-41025](https://bugs.python.org/issue41025?#msg375530) and [bpo-41568](https://bugs.python.org/issue41568), there are two refleaks related to subclassing the C implementation of `ZoneInfo`:

1. `__init_subclass__` leaks a reference to the subclass's weak cache.
2. `ZoneinfoSubclass.clear_cache()` incidentally sets `zoneinfo.ZoneInfo`'s pointer to its strong cache to `NULL`, thus leaking the old strong cache (and forcing `ZoneInfo` to create a new one).