### PR TITLE
Pin pep517 library

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,7 @@ description = Build a wheel and source distribution
 skip_install = True
 passenv = *
 deps =
-    pep517
+    pep517==0.8.2
 commands =
     python -m pep517.build {posargs} {toxinidir} -o {toxinidir}/dist
 


### PR DESCRIPTION
The high level CLI will evidently be removed soon (and suddenly): https://github.com/pypa/pep517/pull/83