### PR TITLE
Update pre commit hooks and remove setup-cfg-fmt

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', 'pypy3']
+        python-version: ["3.6", "3.7", "3.8", "pypy3"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
     env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ["3.6", "3.7", "3.8"]
         os: ["ubuntu-latest"]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,17 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "pypy3"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
+        exclude:
+          # Disable PyPy3 on Windows, because GHA currently serves version
+          # 7.3.2, which has a regression that breaks tox on Windows:
+          #
+          # https://foss.heptapod.net/pypy/pypy/-/issues/3331
+          # https://github.com/tox-dev/tox/issues/1704
+          #
+          # This can be removed when a fixed version of PyPy is available on
+          # GHA, or when a workaround is found.
+          - python-version: "pypy3"
+            os: "windows-latest"
     env:
       TOXENV: py
       TEST_EXTRAS_TOX: ${{ matrix.tzdata_extras }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,26 +6,26 @@ repos:
         language_version: python3.8
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.4.2
+    rev: v5.6.4
     hooks:
       - id: isort
         additional_dependencies: [toml]
         language_version: python3.8
 
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.5.2
+    rev: pylint-2.6.0
     hooks:
     -   id: pylint
 
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
 
   - repo: https://github.com/doublify/pre-commit-clang-format
-    rev: f4c4ac5948aff384af2b439bfabb2bdd65d2b3ac
+    rev: 62302476d0da01515660132d76902359bed0f782
     hooks:
     -   id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,6 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
 
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.9.0
-    hooks:
-    -   id: setup-cfg-fmt
-
   - repo: https://github.com/doublify/pre-commit-clang-format
     rev: f4c4ac5948aff384af2b439bfabb2bdd65d2b3ac
     hooks:

--- a/scripts/update_test_data.py
+++ b/scripts/update_test_data.py
@@ -105,7 +105,8 @@ def update_test_data(fname: str = "zoneinfo_data.json") -> None:
 
     # Annotation required: https://github.com/python/mypy/issues/8772
     json_kwargs: typing.Dict[str, typing.Any] = dict(
-        indent=2, sort_keys=True,
+        indent=2,
+        sort_keys=True,
     )
 
     compressed_keys = load_compressed_keys()

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1563,15 +1563,27 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
         test_cases = [
             [("path/to/somewhere",), ()],
             [
-                ("/usr/share/zoneinfo", "path/to/somewhere",),
+                (
+                    "/usr/share/zoneinfo",
+                    "path/to/somewhere",
+                ),
                 ("/usr/share/zoneinfo",),
             ],
             [("../relative/path",), ()],
             [
-                ("/usr/share/zoneinfo", "../relative/path",),
+                (
+                    "/usr/share/zoneinfo",
+                    "../relative/path",
+                ),
                 ("/usr/share/zoneinfo",),
             ],
-            [("path/to/somewhere", "../relative/path",), ()],
+            [
+                (
+                    "path/to/somewhere",
+                    "../relative/path",
+                ),
+                (),
+            ],
             [
                 (
                     "/usr/share/zoneinfo",
@@ -1603,11 +1615,24 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
     def test_reset_tzpath_relative_paths(self):
         bad_values = [
             ("path/to/somewhere",),
-            ("/usr/share/zoneinfo", "path/to/somewhere",),
+            (
+                "/usr/share/zoneinfo",
+                "path/to/somewhere",
+            ),
             ("../relative/path",),
-            ("/usr/share/zoneinfo", "../relative/path",),
-            ("path/to/somewhere", "../relative/path",),
-            ("/usr/share/zoneinfo", "path/to/somewhere", "../relative/path",),
+            (
+                "/usr/share/zoneinfo",
+                "../relative/path",
+            ),
+            (
+                "path/to/somewhere",
+                "../relative/path",
+            ),
+            (
+                "/usr/share/zoneinfo",
+                "path/to/somewhere",
+                "../relative/path",
+            ),
         ]
         for input_paths in bad_values:
             with self.subTest(input_paths=input_paths):


### PR DESCRIPTION
I guess `black` changed some of how code is formatting, which is causing the linting CI job to break.

This updates all of our pre-commit hooks along with:

1. Changes to the formatting to match the new `black` style (unfortunately this will probably only be reflected in the CPython source code if we have to touch the reformatted parts anyway).
2. Remove `setup-cfg-fmt`. Considering the fact that it is preventing us from including comments in `setup.cfg` (intentionally) and that it auto-populates the trove classifiers with Python 3.9 — which would be inappropriate to either add to the trove classifiers or forbid using `python_requires` — it's doing more harm than good. We'll just have to be diligent about formatting unless we find something better.