### PR TITLE
Run test workflow on PR, not push

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [pull_request]
 
 jobs:
   tests:


### PR DESCRIPTION
When it's just me pushing branches directly to my own namespace there is no difference, but I think this makes it so that the tests aren't triggered when someone else makes a PR.