### PR TITLE
Reintroduce pypy for Windows to CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,17 +10,6 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "pypy3"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
-        exclude:
-          # Disable PyPy3 on Windows, because GHA currently serves version
-          # 7.3.2, which has a regression that breaks tox on Windows:
-          #
-          # https://foss.heptapod.net/pypy/pypy/-/issues/3331
-          # https://github.com/tox-dev/tox/issues/1704
-          #
-          # This can be removed when a fixed version of PyPy is available on
-          # GHA, or when a workaround is found.
-          - python-version: "pypy3"
-            os: "windows-latest"
     env:
       TOXENV: py
       TEST_EXTRAS_TOX: ${{ matrix.tzdata_extras }}
@@ -37,10 +26,12 @@ jobs:
         python -m pip install --upgrade pip tox
     - name: Run tests
       run: |
-        python -m tox
+        python -m tox --discover $(which python)
+      shell: bash
     - name: Report coverage
       run: |
-        tox -e coverage-report,codecov
+        tox -e coverage-report,codecov --discover $(which python)
+      shell: bash
 
   c_coverage:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Hi, I noticed your tox issue regarding PyPy on WIndows. I found a simple workaround that seems like a good enough solution at least until the new PyPy release makes it to Github Actions.