### PR TITLE
Migrate build action to use environment files

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
       - name: Setup python
         uses: actions/setup-python@v1

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -51,13 +51,14 @@ jobs:
       - name: Install docker image
         run: |
           DOCKER_IMAGE="quay.io/pypa/${{ matrix.platform }}"
-          echo "::set-env name=DOCKER_IMAGE::$DOCKER_IMAGE"
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
           docker pull $DOCKER_IMAGE
       - name: Build wheels
         env:
           PYTHON_TAGS: "cp36-cp36m cp37-cp37m cp38-cp38"
           PRE_CMD:  ${{ matrix.platform == 'manylinux1_i686' && 'linux32' || '' }}
         run: |
+          echo "$name"
           docker run --rm \
             -e PLAT=${{ matrix.platform }} \
             -e PYTHON_TAGS="$PYTHON_TAGS" \

--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,13 @@ description = Run the tests
 deps =
     coverage[toml]
     dataclasses; python_version<"3.7"
-    hypothesis>=5.7.0
+    hypothesis>=5.7.0,<5.43
     importlib_metadata; python_version<"3.8"
     pytest
     pytest-cov
     pytest-randomly
     pytest-subtests
     pytest-xdist
-pip_pre = true
 extras =
     {env:TEST_EXTRAS_TOX:}
 setenv =
@@ -32,7 +31,7 @@ description = Run the tests and collect C coverage stats
 deps =
     gcovr
     dataclasses; python_version<"3.7"
-    hypothesis>=5.7.0
+    hypothesis>=5.7.0,<5.43
     importlib_metadata; python_version<"3.8"
     pytest
     pytest-subtests


### PR DESCRIPTION
Apparently there was some CVE for `set-env`. I am not terribly worried about this, but the solution of putting the environment variable definitions into a file seems simple enough.