### PR TITLE
Update zoneinfo tests and test data

### DIFF
--- a/scripts/update_test_data.py
+++ b/scripts/update_test_data.py
@@ -19,7 +19,14 @@ import pathlib
 import textwrap
 import typing
 
-import backports.zoneinfo as zoneinfo
+try:
+    import backports.zoneinfo as zoneinfo
+except ImportError:
+    # Mypy can't handle this try/except definition in multiple blocks,
+    # so we need to tell it to ignore this line for now. See:
+    # https://github.com/python/mypy/issues/1153
+    import zoneinfo  # type: ignore
+
 
 KEYS = [
     "Africa/Abidjan",

--- a/tests/data/zoneinfo_data.json
+++ b/tests/data/zoneinfo_data.json
@@ -6,25 +6,25 @@
       "00dcD"
     ],
     "Africa/Casablanca": [
-      "{Wp48S^xk9=GL@E0stWa761SMbT8$j;0b&Kz+C_;7KxBg5R*{N&yjMUR~;C-fDaSOU;q-~",
+      "{Wp48S^xk9=GL@E0stWa761SMbT8$j;0b&Kvt0lx7KxBg5R*{N&yjMUR~;C-fDaSOU;q-~",
       "FqW+4{YBjbcw}`a!dW>b)R2-0a+uwf`P3{_Y@HuCz}S$J$ZJ>R_V<~|Fk>sgX4=%0vUrh-",
       "lt@YP^Wrus;j?`Th#xRPzf<<~Hp4DH^gZX>d{+WOp~HNu8!{uWu}&XphAd{j1;rB4|9?R!",
       "pqruAFUMt8#*WcrVS{;kLlY(cJRV$w?d2car%R<ALOSO?^`4;ZZtI)%f^^G^>s>q9BgTU4",
       "Ht-tQKZ7Z`9QqOb?R#b%z?rk>!CkH7jy3wja4NG2q)H}fNRKg8v{);Em;K3Cncf4C6&Oaj",
-      "V+DbX%o4+)CV3+e!Lm6dutu(0BQpH1T?W(~cQtKV*^_Pdx!LirjpTs?Bmt@vktjLq4;)O!",
-      "rrly=c*rwTwMJFd0I57`hgkc?=nyI4RZf9W$6DCWugmf&)wk^tWH17owj=#PGH7Xv-?9$j",
-      "njwDlkOE+BFNR9YXEmBpO;rqEw=e2IR-8^(W;8ma?M3JVd($2T>IW+0tk|Gm8>ftukRQ9J",
-      "8k3brzqMnVyjsLI-CKneFa)Lxvp_a<CkQEd#(pMA^rr}rBNElGA=*!M)puBdoErR9{kWL@",
-      "w=svMc6eZ^-(vQZrV<u^PY#nOIUDJ8%A&;BUVlY9=;@i2j2J1_`P>q40f}0J3VVoWL5rox",
-      "`Kptivcp}o5xA^@>qNI%?zo=Yj4AMV?kbAA)j(1%)+Pp)bSn+7Yk`M{oE}L-Z!G6<Dgq&*",
-      "(C-mFJfbEGDH5M^vBr65rcnsx*~|Em_GeU#B)(+T!|MG-nxj0@IPbp-nHejH3~>OMr5G+h",
-      "p)$3Lg{ono{4cN>Vr&>L4kXH;_VnBL5U!LgzqE%P7QQ*<E!guRW2SE@ayq@)G2nXqA2tGo",
-      "QIgc6>tue}O`3(TZ0`aKn&~8trOQ-rBXCp)f@P6RMO4l0+;b|5-pk9_ryNh}Zc*v%mvz_#",
-      "yd<xXt%~gT90dn4e{Ac<baL-)Y{L7&5G($I$>6fjB0g9{MmMnu8bG%#C~ugXK^S^k@?ab#",
-      "O|aE>dDTt4s4n69(~@t~!wniV%g<uWQat_i6>7khFx~I*4>Y|V$4j5%KPF*-FyKIi@!Ho&",
-      "x8QQsksYt8)D+W)Ni!=G`ogSu^vLL-l#7A7=iIAKL2SuZk9F}NfNk86VI)9WZE?%2wC-ya",
-      "F~z#Qsq)LH0|_D8^5fU8X%GeQ4TB>R-dlziA&tZe&1ada208!$nk`7bOFO2S00G<w{Sp8G",
-      "{cR_IvBYQl0ssI200dcD"
+      "V+DbX%o4+)CV3+e!Lm6dutu(8G?7*LU}l{M47qtt*0#|bTq9ZFCzMCvD{QVT{VK!ER=XmV",
+      "_-dsW$Sr7HoMnC}a3`9{?BszdA)i?**$VeBAFh4`$Rj~t1H{9yh~yPz5?A38P0%#H;!wF0",
+      "&|3CJYv)`j1jiOHy??e_8g`LC*&&Tz=pFZ$FJ6QSeK}6U3!zrp2@Ufcf_oYm(1z=m6vCiH",
+      "Lgj_N_YtU^UDD=sm1Y%;?-ap-I1$)Tiy;}L7J`%3=1%QdY;x9D#1gv+aIQi%0}}tp^~Rzy",
+      "nc~HIS#@ZvQg@+Pz?;uj3fi7JTFscBQZ%VTr?35(PN%7dgvCSGa17=VTVuecvv)iGzoda&",
+      "{n!Nd>XRmuu{<*JIavM`cd>%$$zfMq;#fDZS4nw+HG61br6Ks;-*q?*|9Yi+bd2o3>$AcJ",
+      "H2@qU&;R1zFlxPd?`BFObWMKCH~mkR!|zibD})8N8Sf8Di=5A79-^;J=O=rzbCGMl^yG2M",
+      "?RJ4hBh4C`oFo(!W)j3yKiSz%3Ka^Xg`=q`yHC}qVXW`*BkZIO^tQumRjV$MY|W>N<q4wi",
+      "5`xd8;5rvl%%jiYM+I|;8VJoBCYOA$(Nd_kzJzsj9MdSfO^Kl*f~l~mshmNk4tgxZ*H?Es",
+      "9YI27T5~^ED3I+hW8v!KRdx3Lx{au2wj{1ufcJdaZ;Am{^~C(3C<@i%H<mxr@YP1ih+<Pe",
+      "DKeH8`tPV{6h==!CI`Ilu#SJOJ>ar*b#9*5-YWpyqUv_ipx)G_Yz*XheqU%n%<~u6alsiT",
+      "60<=y0xjKJSUs10Ffxmww={b8XX~?ryRK%%rlvM4AHYSMupWmp+x3&!laKyMcL!JwCSiq+",
+      "!!I>B!SWa}rg~PbhxR7h#0Ti&W3GNY5&!@Iqpvg9FTIyA00GYj{Sp8G$Q@<+vBYQl0ssI2",
+      "00dcD"
     ],
     "America/Los_Angeles": [
       "{Wp48S^xk9=GL@E0stWa761SMbT8$j;0qH3OkDsf7KxBg5R*;z{h&-RlhRYu$%jt%!jv+I",
@@ -77,22 +77,22 @@
       "dIxbZ00Ex?wE_SDJu@vkvBYQl0ssI200dcD"
     ],
     "Australia/Sydney": [
-      "{Wp48S^xk9=GL@E0stWa761SMbT8$j;0T)o7+nA=7KxBg5R*_t6jS5T`_Ull(nK1_YY;k%",
-      ";_YdTuU3*!K)eKg@^kzjAtbo@Jd|KGai=Q%%sX5FI?*?LG!|m9cKH5~IEwI=PAr_Yc}w35",
-      ">}hOdk<>TdUa07R(LPI6@!GU$ty4=mwqHG-XVe*n(Yvgdlr+FqIU18!osi)48t~eWX8)&L",
-      "G)Ud^0zz@*AF+2r7E}N<P$kOfo*88g)_bOO?7N1Jr|HJyg+HXc7f4}?%Dur3w|~JU?<x4K",
-      "%RRC~q_D87;UyN{nLRu!fEqKeRR*U$vs>f9Y72K~o-T%}D&z%}#7g<qim`EbfhF7ntyAiP",
-      "%LFNc&!$@Kv)Olyf&Y9%(#SkM+%yI}S%b+@ZM2dH7DpmndGMIda<(`#E9q|?H(HzClx+l;",
-      "M?IEz1eF}r?}ay!V9?9rKD^-ayjE@wUMD$2kC!iwH`n=eVrJPmJyNKaW`LdJ68&u;2nF1K",
-      "kZjKCY_A<>2br?oH6ZiYH^%>J3D)TPKV(JY*bwjuw5=DsPB@~CrR<E_U_fJTF9ufU%!cXK",
-      "_4uM#!%%Q1e1G~{E}~vGVE0{Kxecm^NjtJM`c8EFHFTiUIVl@YUD8F+s!u8jz~6hte@oa|",
-      "qayb*^Lwd(etNmBro;aXQjkY8g(*`_JQ0%{V3QP2l!GGQ7D+v&k_PK0F(?f{GziU5>OZeN",
-      "x>A*H&CHrWt0`EP`m!F%waepl#|w#&`XgVc?~2M3uw$fGX~tf_Il!q#Aa<*8xlzQ2+7r6Z",
-      "^;Laa9F(WB_O&Dy2r>~@kSi16W{=6+i5GV=Uq~KX*~&HUN4oz7*O(gXIr}sDVcD`Ikgw#|",
-      "50ssal8s)Qy;?YGCf;*UKKKN!T4!Kqy_G;7<gSrPK{)5#a>PfQapugqvVBKy12v3TVH^L2",
-      "0?#5*VP~MOYfe$h`*L!7@tiW|_^X1N%<}`7YahiUYtMu5XwmOf3?dr+@zXHwW`z}ZDqZlT",
-      "<2Cs(<1%M!i6o&VK89BY0J7HPIo;O62s=|IbV^@y$N&#<x=a876<(U>=>i^F00FcHoDl#3",
-      "Mdv&xvBYQl0ssI200dcD"
+      "{Wp48S^xk9=GL@E0stWa761SMbT8$j;0TQa5M2N&7KxBg5R*_t3)o}P`_Ull(nK1~U=~g{",
+      "!2#v7ta-VPM|>+w;XP~5#XzS!mmq>y(@${PQsHdkBYiJixTuCQ2N?55>HhxKTEufgeVl}_",
+      "Sq_FUIXFF$kI6!-eKVzudw1Zyg8;a%MynCz&_3Cl@%Zs*_JRo#I#Ss92V)!~{AwVung!|w",
+      "K?4JFyFv#=nfhNI6Czr|3VjINV7V6#eFr=Gl1UDdL9MQRWZ`RiZET+f<B?psO04A!^T@|O",
+      "jD(g9%6r^uKWL~*l5l((#kszU!MR&R^KmhB+uQG;V@@lt4iky54!7C3s3sgfut6UfX5na|",
+      "U#Q8$>l#=kxZ_-G@=#VCQEvCZVdj9;e?rY8ynpo&34D<xf3gdy0mso_&ACxT<X@=iK)(!)",
+      "Cf=UJXS@mJ>Pa3KI_Sc_0#?r^44F}Rzb_ChM7PPrq3@FkqqjWqgvOzPq+vkb;DT&2YMC|t",
+      "C3lu6Ihz2prrFPvOU@6I3$XU@68kFFWx8fx?jt@frXW`;AZso*plI73>*wENVoc+2cm`jg",
+      "oe6(B`w`{Bdx<i@MbN&WNDIQhD$&B-uG<$!*}1d++*d~BtG=}tp$n^wQ7tVUh5HXx%pYRB",
+      "r8eErtbe5x3d1_@!5Dfbr?|~LLM#@TJp{TC>VOWD1rqV<x%ZP)Pc1Wb+mhO{S8(-3ndm1j",
+      "Ww?3!z_VRO<>TCN+Y4kRvHLYXlr)vU4G7S$p~Ia_n|G>=3N5dDB8cS6IGd-ckfc78#^71H",
+      "tN_BO2#F%&%Ll+IhR1DlEUG@+#_Yl8AKa1US?{&+yOwA=WA=!z-B9t2>Tn9Wu2*8Ydrbag",
+      "e(I4dkD_vcP(|c-LhGRkSn{W*nk?RJQN!j1RSZ}L6e<&UGMisk>nLH5JiLNgOSC7c&Mn1+",
+      "Pit*Gz;s=M?_q!vDZ@dJctlzl2>W(rvs{(CERM)RT0xuqDAl{)$*ztEhe=?|;3u&!6O1c8",
+      "8W}SFHDBBHh%rrhU6=f6kjYt!N19xk*s_9IpbeS;(cPoTPX!vr00FE9ju8L=r}(KdvBYQl",
+      "0ssI200dcD"
     ],
     "Europe/Dublin": [
       "{Wp48S^xk9=GL@E0stWa761SMbT8$j;0>b$_+0=h7KxBg5R*;&J77#T_U2R5sleVWFDmK~",
@@ -185,6 +185,6 @@
     ]
   },
   "metadata": {
-    "version": "2020a"
+    "version": "2021a"
   }
 }

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -2051,8 +2051,8 @@ class ZoneDumpData:
 
             return [
                 ZoneTransition(datetime(1895, 2, 1), LMT, AEST),
-                ZoneTransition(datetime(1917, 1, 1, 0, 1), AEST, AEDT),
-                ZoneTransition(datetime(1917, 3, 25, 2), AEDT, AEST),
+                ZoneTransition(datetime(1917, 1, 1, 2), AEST, AEDT),
+                ZoneTransition(datetime(1917, 3, 25, 3), AEDT, AEST),
                 ZoneTransition(datetime(2012, 4, 1, 3), AEDT, AEST),
                 ZoneTransition(datetime(2012, 10, 7, 2), AEST, AEDT),
                 ZoneTransition(datetime(2040, 4, 1, 3), AEDT, AEST),


### PR DESCRIPTION
Historical updates to Australia/Sydney would break the tests starting with 2020e. This leads to a discrepancy between how the test suite fairs with the latest `tzdata` installed and the pinned data we've vendored.

The relevant commit on github.com/eggert/tz is 1aca4cad3692063cd5cb571883ccf6d04b3c2991

https://mm.icann.org/pipermail/tz/2020-November/029496.html

This updates the pinned data and our tests.