### PR TITLE
Use pypa/build in favor of pep517.build

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           CL: ${{ matrix.os == 'windows-latest' && '/WX' || '' }}
         run: |
-          tox -e build -- -b
+          tox -e build -- -w
       - uses: actions/upload-artifact@v2
         with:
           name: dist

--- a/scripts/build_manylinux_wheels.sh
+++ b/scripts/build_manylinux_wheels.sh
@@ -15,7 +15,7 @@ cd /io/
 for tag in $PYTHON_TAGS; do
     PYBIN="/opt/python/$tag/bin/"
     ${PYBIN}/pip install tox
-    CFLAGS="-std=c99 -O3" ${PYBIN}/tox -e build -- -b
+    CFLAGS="-std=c99 -O3" ${PYBIN}/tox -e build -- -w
 done
 
 mv dist/ raw_wheels

--- a/tox.ini
+++ b/tox.ini
@@ -129,9 +129,9 @@ description = Build a wheel and source distribution
 skip_install = True
 passenv = *
 deps =
-    pep517
+    build
 commands =
-    python -m pep517.build {posargs} {toxinidir} -o {toxinidir}/dist
+    python -m build {posargs} {toxinidir} -o {toxinidir}/dist
 
 [testenv:build-check]
 description = Build a wheel and source distribution


### PR DESCRIPTION
`pep517.build` is deprecated and pypa/build is ready, so we can and should switch over now.

Replaces #91 