### PR TITLE
Re-enable PyPy tests on Windows

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,17 +10,6 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "pypy3"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         tzdata_extras: ["", "tzdata"]
-        exclude:
-          # Disable PyPy3 on Windows, because GHA currently serves version
-          # 7.3.2, which has a regression that breaks tox on Windows:
-          #
-          # https://foss.heptapod.net/pypy/pypy/-/issues/3331
-          # https://github.com/tox-dev/tox/issues/1704
-          #
-          # This can be removed when a fixed version of PyPy is available on
-          # GHA, or when a workaround is found.
-          - python-version: "pypy3"
-            os: "windows-latest"
     env:
       TOXENV: py
       TEST_EXTRAS_TOX: ${{ matrix.tzdata_extras }}


### PR DESCRIPTION
It seems that https://foss.heptapod.net/pypy/pypy/-/issues/3331 and https://github.com/tox-dev/tox/issues/1704 have been closed for some time now, and the changes should be rolled out to Github Actions by now 🤞.

Replaces #95, which has a workaround that shouldn't be needed anymore.