### PR TITLE
ci: add Python 3.8 universal build

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -115,6 +115,23 @@ jobs:
           name: dist
           path: dist
 
+  build_cibw:
+    runs-on: macos-latest
+    name: 'Build wheel: macos-latest 3.8 (universal2)'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pypa/cibuildwheel@v1.12.0
+        with:
+          output-dir: dist
+        env:
+          CIBW_BUILD: cp38-macosx_universal2
+          CIBW_ARCHS_MACOS: universal2
+          CIBW_TEST_SKIP: '*universal2:arm64'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
   deploy:
     runs-on: 'ubuntu-latest'
     needs: [build_sdist, build_wheel, build_manylinux_wheels]


### PR DESCRIPTION
This adds a CPython 3.8 Universal2 wheel for macOS. Tested on an Apple Silicon machine locally using the default Python 3.8 that Apple ships on Big Sur.

The other wheels do not support macOS < 10.14, I would highly recommend supporting 10.9+ instead of \<whatever minimum macOS CI ships with\>, for example by manually downloading the 10.9+ official release of CPython from python.org, or using a simliar procedure as in this PR. ;)