### PR TITLE
Fix conditional that defines ATLEAST_37.

### DIFF
--- a/lib/zoneinfo_module.c
+++ b/lib/zoneinfo_module.c
@@ -7,7 +7,7 @@
 
 #include "datetime.h"
 
-#if PY_VERSION_HEX < 0x03070000
+#if PY_VERSION_HEX >= 0x03070000
 #define ATLEAST_37
 #ifdef MS_WINDOWS
 #undef _tzname


### PR DESCRIPTION
Hi!

Compilation is failing for me on Python 3.10. It looks like there's some compatibility code for versions before 3.7 vs 3.7 and later. However, the condition to define `ATLEAST_37` seems to have the opposite test of what it should.