### PR TITLE
Fix some GitHub Actions things

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: Build sdist
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
           pip3 install tox
       - name: Build sdist
         run: tox -e build -- -s
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
@@ -48,8 +48,8 @@ jobs:
           - 'manylinux2014_aarch64'
     name: Build a ${{ matrix.platform }} for ${{ matrix.python_tag }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
         if: ${{ matrix.platform == 'manylinux2014_aarch64' }}
         name: Set up QEMU
       - name: Install docker image
@@ -69,7 +69,7 @@ jobs:
             -v `pwd`:/io "$DOCKER_IMAGE" \
             $PRE_CMD \
             /io/scripts/build_manylinux_wheels.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
@@ -90,12 +90,12 @@ jobs:
 
     name: 'Build wheel: ${{ matrix.os }} ${{ matrix.python_version }} (${{ matrix.arch }})'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
         if: matrix.os == 'windows-latest'
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
           architecture: ${{ matrix.arch }}
@@ -110,7 +110,7 @@ jobs:
           CL: ${{ matrix.os == 'windows-latest' && '/WX' || '' }}
         run: |
           tox -e build -- -w
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
@@ -119,12 +119,12 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: [build_sdist, build_wheel, build_manylinux_wheels]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "pypy3"]
         os: ["ubuntu-22.04", "windows-2022", "macos-11"]
@@ -43,6 +44,7 @@ jobs:
   c_coverage:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
         os: ["ubuntu-latest"]
@@ -64,6 +66,7 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
       matrix:
         cc: ["gcc", "clang"]
     env:
@@ -89,6 +92,7 @@ jobs:
   other:
     runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
       matrix:
         toxenv: ["lint", "docs", "mypy"]
     env:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,18 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "pypy3"]
+        python-version: ["3.7", "3.8", "pypy3"]
         os: ["ubuntu-22.04", "windows-2022", "macos-11"]
         tzdata_extras: ["", "tzdata"]
-        exclude:
-          - python-version: "3.6"
         include:
-          - python-version: "3.6"
-            os: "ubuntu-20.04"
-          - python-version: "3.6"
-            os: "windows-2019"
-          - python-version: "3.6"
-            os: "macos-10.15"
+          - { python-version: "3.6",  os: "windows-2019", tzdata_extras: "" }
+          - { python-version: "3.6",  os: "windows-2019", tzdata_extras: "tzdata" }
+          - { python-version: "3.6",  os: "macos-10.15", tzdata_extras: "" }
+          - { python-version: "3.6",  os: "macos-10.15", tzdata_extras: "tzdata" }
+          - { python-version: "3.6",  os: "ubuntu-20.04", tzdata_extras: "" }
+          - { python-version: "3.6",  os: "ubuntu-20.04", tzdata_extras: "tzdata" }
     env:
       TOXENV: py
       TEST_EXTRAS_TOX: ${{ matrix.tzdata_extras }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,9 +26,9 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: ${{ matrix.python-version }} - ${{ matrix.os }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -51,9 +51,9 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: C coverage - ${{ matrix.os }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -79,9 +79,9 @@ jobs:
         -Wno-unused-parameter
         -Wno-missing-field-initializers
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ${{ matrix.toxenv }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install tox
@@ -99,9 +99,9 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ${{ matrix.toxenv }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install tox

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,8 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8"]
         os: ["ubuntu-latest"]
+        include:
+          - { python-version: "3.6",  os: "ubuntu-20.04" }
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   tests:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@ project = "backports.zoneinfo"
 author = "Paul Ganssle"
 copyright = f"2020, {author}"
 
+
 # Read the version information from the _version.py file
 def get_version():
     import ast

--- a/src/backports/zoneinfo/_tzpath.py
+++ b/src/backports/zoneinfo/_tzpath.py
@@ -85,7 +85,6 @@ if sys.version_info < (3, 8):
         except ValueError:
             return False
 
-
 else:
     _isfile = os.path.isfile
 

--- a/src/backports/zoneinfo/_zoneinfo.py
+++ b/src/backports/zoneinfo/_zoneinfo.py
@@ -11,6 +11,7 @@ from . import _common, _tzpath
 EPOCH = datetime(1970, 1, 1)
 EPOCHORDINAL = datetime(1970, 1, 1).toordinal()
 
+
 # It is relatively expensive to construct new timedelta objects, and in most
 # cases we're looking at the same deltas, like integer numbers of hours, etc.
 # To improve speed and memory use, we'll keep a dictionary with references

--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -503,7 +503,7 @@ class ZoneInfoV1Test(ZoneInfoTest):
         # We will discard zdump examples outside the range epoch +/- 2**31,
         # because they are not well-supported in Version 1 files.
         epoch = datetime(1970, 1, 1)
-        max_offset_32 = timedelta(seconds=2 ** 31)
+        max_offset_32 = timedelta(seconds=2**31)
         min_dt = epoch - max_offset_32
         max_dt = epoch + max_offset_32
 
@@ -795,8 +795,8 @@ class WeirdZoneTest(ZoneInfoTestBase):
         trans_times_lists = [[], []]
         trans_idx_lists = [[], []]
 
-        v1_range = (-(2 ** 31), 2 ** 31)
-        v2_range = (-(2 ** 63), 2 ** 63)
+        v1_range = (-(2**31), 2**31)
+        v2_range = (-(2**63), 2**63)
         ranges = [v1_range, v2_range]
 
         def zt_as_tuple(zt):
@@ -1327,7 +1327,6 @@ class ZoneInfoCacheTest(TzPathUserMixin, ZoneInfoTestBase):
         self.assertIs(tz0, tz1)
 
     def test_no_cache(self):
-
         tz0 = self.klass("Europe/Lisbon")
         tz1 = self.klass.no_cache("Europe/Lisbon")
 

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -58,9 +58,9 @@ def test_reset_tzpath() -> None:
     zoneinfo.reset_tzpath()
 
 
-def test_offset() -> Sequence[
-    Tuple[Optional[str], Optional[timedelta], Optional[timedelta]]
-]:
+def test_offset() -> (
+    Sequence[Tuple[Optional[str], Optional[timedelta], Optional[timedelta]]]
+):
     LA: zoneinfo.ZoneInfo = zoneinfo.ZoneInfo("America/Los_Angeles")
     dt: datetime = datetime(2020, 1, 1, tzinfo=LA)
 


### PR DESCRIPTION
This PR updates PR https://github.com/pganssle/zoneinfo/pull/127, and gets the CI running again for Python 3.6. 

The "Build and release" workflow now passes, and the "Python package" workflow has failing tests, but it's progress! At least they're running! 🚀 

Things done here:

* Bump GitHub Actions versions
* Allow all jobs to continue if one fails: to see which pass, which need fixes
* Update the matrix so EOL Python 3.6 is run using older (deprecated) runners
* Apply Black formatting to fix part of linting

---

A quick look at some failures:

```
File "/home/runner/work/zoneinfo/zoneinfo/.tox/py/lib/python3.7/site-packages/_pytest/assertion/rewrite.py", line 168, in exec_module
    exec(co, module.__dict__)
  File "/home/runner/work/zoneinfo/zoneinfo/.tox/py/lib/python3.7/site-packages/hypothesis/__init__.py", line 53, in <module>
    run()
  File "/home/runner/work/zoneinfo/zoneinfo/.tox/py/lib/python3.7/site-packages/hypothesis/entry_points.py", line 61, in run
    for entry in get_entry_points():  # pragma: no cover
  File "/home/runner/work/zoneinfo/zoneinfo/.tox/py/lib/python3.7/site-packages/hypothesis/entry_points.py", line 32, in get_entry_points
    yield from importlib_metadata.entry_points().get("hypothesis", [])
AttributeError: 'EntryPoints' object has no attribute 'get'
py: exit 1 (0.67 seconds) /home/runner/work/zoneinfo/zoneinfo> pytest /home/runner/work/zoneinfo/zoneinfo --cov=backports.zoneinfo --cov=tests pid=1[81](https://github.com/hugovk/zoneinfo/actions/runs/4336606519/jobs/7572017561#step:5:82)2
```

Looks like https://github.com/HypothesisWorks/hypothesis/issues/3473, already fixed in a newer version, so would need the pin bumped in tox.ini and another solution found for the reason it was originally pinned: https://github.com/pganssle/zoneinfo/commit/4845961fba397deacaf47a38689a6298af9c63bb

