### PR TITLE
Handle check for PYTHONTZPATH failing

### DIFF
--- a/tests/test_zoneinfo.py
+++ b/tests/test_zoneinfo.py
@@ -1532,13 +1532,20 @@ class TzPathTest(TzPathUserMixin, ZoneInfoTestBase):
     @contextlib.contextmanager
     def python_tzpath_context(value):
         path_var = "PYTHONTZPATH"
+        unset_env_sentinel = object()
+        old_env = unset_env_sentinel
         try:
             with OS_ENV_LOCK:
                 old_env = os.environ.get(path_var, None)
                 os.environ[path_var] = value
                 yield
         finally:
-            if old_env is None:
+            if old_env is unset_env_sentinel:
+                # In this case, `old_env` was never retrieved from the
+                # environment for whatever reason, so there's no need to
+                # reset the environment TZPATH.
+                pass
+            elif old_env is None:
                 del os.environ[path_var]
             else:
                 os.environ[path_var] = old_env  # pragma: nocover


### PR DESCRIPTION
It is possible but unlikely for the `python_tzpath_context` function to fail between the start of the `try` block and the point where `os.environ.get` succeeds, in which case `old_env` will be undefined. In this case, we want to take no action.

Practically speaking this will really only happen in an error condition anyway, so it doesn't really matter, but we should probably do it right anyway.

This will also fix the `lint` CLI, which has apparently just recently started noticing that there's a potential used-before-assignment error here.