### PR TITLE
GitHub Action to lint Python code with ruff

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -126,6 +126,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: pip install --user ruff
-    - run: ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
     - run: ruff --format=github --line-length=97 --select-F401,F541,F841 --target-version=py37 .
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -121,3 +121,11 @@ jobs:
           else
             tox
           fi
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
+    - run: ruff --format=github --line-length=97 --select-F401,F541,F841 --target-version=py37 .
+

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -126,5 +126,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: pip install --user ruff
-    - run: ruff --format=github --line-length=97 --select-F401,F541,F841 --target-version=py37 .
+    - run: ruff --format=github --line-length=97 --select=F401,F541,F841 --target-version=py37 .
 


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)