### PR TITLE
Build wheels on PR

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -15,6 +15,7 @@ on:
   push:
   release:
     types: [created]
+  pull_request:
 
 jobs:
   build_sdist:
@@ -120,6 +121,7 @@ jobs:
           path: dist
 
   deploy:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: 'ubuntu-22.04'
     needs: [build_sdist, build_wheel, build_manylinux_wheels]
     steps:


### PR DESCRIPTION
Currently we only build wheels as part of deployment, but for things like testing whether or not new wheel-building configurations work, it makes sense ot also test wheel-building on PR.

This will be useful for stuff like #136 